### PR TITLE
Change the library name of common_clang to opencl_clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # we force using response files
 set(CMAKE_NINJA_FORCE_RESPONSE_FILE 1)
 
+set(COMMON_CLANG_LIBRARY_NAME "opencl_clang")
+
 # We want to build with the static, multithreaded runtime libraries (as opposed
 # to the multithreaded runtime DLLs)
 if(MSVC)

--- a/package.cmake
+++ b/package.cmake
@@ -40,7 +40,7 @@ if(UNIX)
     ${IGDRCL_BINARY_DIR}/bin/libigdccl.so
     ${IGDRCL_BINARY_DIR}/bin/libigdfcl.so
     ${IGDRCL_BINARY_DIR}/bin/libiga64.so
-    ${IGDRCL_BINARY_DIR}/bin/libcommon_clang.so
+    ${IGDRCL_BINARY_DIR}/bin/lib${COMMON_CLANG_LIBRARY_NAME}.so
     DESTINATION ${NEO_BINARY_INSTALL_DIR}
     COMPONENT igdrcl
   )


### PR DESCRIPTION
This is a fix for https://github.com/intel/compute-runtime/issues/21
This change has dependencies on following common_clang and intel-graphics-compiler pull requests, and should be merged after they are accepted:
https://github.com/intel/opencl-clang/pull/2
https://github.com/intel/intel-graphics-compiler/pull/8