### PR TITLE
Prevent pointer derefence crash on failure to load libva library

### DIFF
--- a/runtime/sharings/va/va_sharing_functions.cpp
+++ b/runtime/sharings/va/va_sharing_functions.cpp
@@ -63,7 +63,7 @@ void VASharingFunctions::initFunctions() {
             vaGetLibFuncPFN = (VAGetLibFuncPFN)fdlsym(libHandle, "vaGetLibFunc");
             vaExtGetSurfaceHandlePFN = (VAExtGetSurfaceHandlePFN)getLibFunc("DdiMedia_ExtGetSurfaceHandle");
         } else {
-            vaDisplayIsValidPFN = nullptr;
+            vaDisplayIsValidPFN = vaDefaultDisplayIsValidPFN;
             vaDeriveImagePFN = nullptr;
             vaDestroyImagePFN = nullptr;
             vaSyncSurfacePFN = nullptr;

--- a/runtime/sharings/va/va_sharing_functions.h
+++ b/runtime/sharings/va/va_sharing_functions.h
@@ -73,7 +73,10 @@ class VASharingFunctions : public SharingFunctions {
   protected:
     void *libHandle = nullptr;
     VADisplay vaDisplay = nullptr;
-    VADisplayIsValidPFN vaDisplayIsValidPFN = [](VADisplay vaDisplay) { return 0; };
+
+    const VADisplayIsValidPFN vaDefaultDisplayIsValidPFN = [](VADisplay vaDisplay) { return 0; };
+
+    VADisplayIsValidPFN vaDisplayIsValidPFN = vaDefaultDisplayIsValidPFN;
     VADeriveImagePFN vaDeriveImagePFN;
     VADestroyImagePFN vaDestroyImagePFN;
     VASyncSurfacePFN vaSyncSurfacePFN;


### PR DESCRIPTION
vaDisplayIsValidPFN is a special case in VASharingFunctions. Even
if libva was not loaded this function could be called thru
VASharingFunctions::isValidVaDisplay which is the case in NEO
driver: see VaSharingContextBuilder::finalizeProperties. Mind that
libva could be of different versions: 1.x, 2.x, etc. Which means
that situations possible that application passed valid VADisplay
for libva-2.x, but NEO driver tries to load libva-1.x.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>