### PR TITLE
ci: add fix for builds on Fedora systems in docker container

### DIFF
--- a/scripts/build-fedora27-copr-docker.sh
+++ b/scripts/build-fedora27-copr-docker.sh
@@ -21,5 +21,6 @@
 
 git fetch -t
 git clone ../compute-runtime neo
+docker info
 docker build -f scripts/docker/Dockerfile-fedora-27-copr-gcc-7 -t neo-fedora-27-copr-gcc-7:ci .
 

--- a/scripts/build-fedora28-copr-docker.sh
+++ b/scripts/build-fedora28-copr-docker.sh
@@ -21,5 +21,6 @@
 
 git fetch -t
 git clone ../compute-runtime neo
+docker info
 docker build -f scripts/docker/Dockerfile-fedora-28-copr-gcc-8 -t neo-fedora-28-copr-gcc-8:ci .
 

--- a/scripts/docker/Dockerfile-fedora-27-copr-gcc-7
+++ b/scripts/docker/Dockerfile-fedora-27-copr-gcc-7
@@ -3,11 +3,11 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config
-RUN dnf install -y 'dnf-command(copr)'
-RUN dnf copr enable -y arturh/intel-opencl
-RUN dnf install -y intel-igc-opencl-devel 
-RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
-RUN mkdir /root/build; cd /root/build ; cmake -G Ninja ../neo; \
+RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
+    dnf install -y 'dnf-command(copr)'; \
+    dnf copr enable -y arturh/intel-opencl; \
+    dnf install -y intel-igc-opencl-devel; \
+    cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib; \
+    mkdir /root/build; cd /root/build ; cmake -G Ninja ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile-fedora-28-copr-gcc-8
+++ b/scripts/docker/Dockerfile-fedora-28-copr-gcc-8
@@ -3,11 +3,11 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config
-RUN dnf install -y 'dnf-command(copr)'
-RUN dnf copr enable -y arturh/intel-opencl
-RUN dnf install -y intel-igc-opencl-devel 
-RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
-RUN mkdir /root/build; cd /root/build ; cmake -G Ninja ../neo; \
+RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
+    dnf install -y 'dnf-command(copr)'; \
+    dnf copr enable -y arturh/intel-opencl; \
+    dnf install -y intel-igc-opencl-devel; \
+    cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib; \
+    mkdir /root/build; cd /root/build ; cmake -G Ninja ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]


### PR DESCRIPTION
fix for dnf install issue:
error: rpmdb: BDB0689 Packages page 465 is on free list with type 7
error: rpmdb: BDB0061 PANIC: Invalid argument

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>