### PR TITLE
ci: use LP ocl-dev account for CI builds on Ubuntu and Arch

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu-16.04-clang-4
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-clang-4
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build intel-igc-opencl-dev clang-4.0
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-clang-5
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-clang-5
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build intel-igc-opencl-dev clang-5.0
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-ppa-gcc-5
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-ppa-gcc-5
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build intel-igc-opencl-dev
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-4
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-4
@@ -4,8 +4,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 COPY neo /root/neo
 
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build intel-igc-opencl-dev clang-4.0
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-5
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-5
@@ -4,8 +4,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 COPY neo /root/neo
 
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build intel-igc-opencl-dev clang-5.0
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-6
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-6
@@ -4,8 +4,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 COPY neo /root/neo
 
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build intel-igc-opencl-dev clang-6.0
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build intel-igc-opencl-dev
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build intel-igc-opencl-dev
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-ppa-gcc-5
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-ppa-gcc-5
@@ -3,8 +3,8 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
-    echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
     apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build intel-igc-opencl-dev
 RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -12,8 +12,8 @@ wait_apt() {
 		sleep 5
 	done
 }
-echo "deb http://ppa.launchpad.net/intel-opencl/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B9732172C4830B8F
+echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1
 
 apt-get -y update
 if [ $? -ne 0 ]

--- a/scripts/prepare-arch-igc-ppa.sh
+++ b/scripts/prepare-arch-igc-ppa.sh
@@ -5,18 +5,18 @@
 # SPDX-License-Identifier: MIT
 #
 
-IGC_VER=18.33.809-1
+IGC_VER=18.38.907-1
 
 cd /root
 
 install_libs() {
-    wget https://launchpad.net/~intel-opencl/+archive/ubuntu/intel-opencl/+files/$1
+    wget https://launchpad.net/~ocl-dev/+archive/ubuntu/intel-opencl/+files/$1
     ar -x $1
     tar -xJf data.tar.xz
     rm -f data.tar.xz $1
 }
 
-install_libs intel-opencl-clang_4.0.15-1~ppa1~bionic1_amd64.deb
+install_libs intel-opencl-clang_4.0.16-1~ppa1~bionic1_amd64.deb
 install_libs intel-igc-core_${IGC_VER}~ppa1~bionic1_amd64.deb
 install_libs intel-igc-opencl-dev_${IGC_VER}~ppa1~bionic1_amd64.deb
 install_libs intel-igc-opencl_${IGC_VER}~ppa1~bionic1_amd64.deb


### PR DESCRIPTION
Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>