### PR TITLE
use intel-gmmlib-* packages to build Neo on Fedora 28

### DIFF
--- a/scripts/docker/Dockerfile-fedora-28-copr-gcc-8
+++ b/scripts/docker/Dockerfile-fedora-28-copr-gcc-8
@@ -9,9 +9,8 @@ RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
     dnf copr enable -y arturh/intel-opencl-experimental; \
     dnf copr enable -y arturh/intel-opencl-unstable; \
     dnf copr enable -y arturh/intel-opencl; \
-    dnf --showduplicate list intel-igc-opencl-devel; \
-    dnf install -y intel-igc-opencl-devel; \
-    cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib; \
+    dnf --showduplicate list intel-igc-opencl-devel intel-gmmlib-devel; \
+    dnf install -y intel-igc-opencl-devel intel-gmmlib-devel; \
     mkdir /root/build; cd /root/build ; cmake -G Ninja ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]


### PR DESCRIPTION
Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>