### PR TITLE
update Arch builds

### DIFF
--- a/scripts/docker/Dockerfile-arch-ppa-gcc-8
+++ b/scripts/docker/Dockerfile-arch-ppa-gcc-8
@@ -2,11 +2,10 @@ FROM docker.io/base/archlinux
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-COPY scripts/prepare-arch-igc-ppa.sh /root
+COPY scripts/prepare-arch-dep-ppa.sh /root
 
 RUN pacman -Sy --noconfirm gcc cmake git wget pkg-config ninja
-RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
-RUN /root/prepare-arch-igc-ppa.sh
-RUN cd /root/build ; cmake -G Ninja -DBUILD_TYPE=Release -DCMAKE_BUILD_TYPE=Release \
+RUN /root/prepare-arch-dep-ppa.sh
+RUN cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/prepare-arch-dep-ppa.sh
+++ b/scripts/prepare-arch-dep-ppa.sh
@@ -5,9 +5,12 @@
 # SPDX-License-Identifier: MIT
 #
 
-IGC_VER=18.38.907-1
-
 cd /root
+IGC_VER="`grep igc_version_required neo/scripts/fedora.spec.in | grep global | awk '{print $3}'`-1"
+GMM_VER="`grep gmmlib_version_required neo/scripts/fedora.spec.in | grep global | awk '{print $3}'`-1"
+
+echo "IGC_VER=${IGC_VER}"
+echo "GMM_VER=${GMM_VER}"
 
 install_libs() {
     wget https://launchpad.net/~ocl-dev/+archive/ubuntu/intel-opencl/+files/$1
@@ -20,9 +23,10 @@ install_libs intel-opencl-clang_4.0.16-1~ppa1~bionic1_amd64.deb
 install_libs intel-igc-core_${IGC_VER}~ppa1~bionic1_amd64.deb
 install_libs intel-igc-opencl-dev_${IGC_VER}~ppa1~bionic1_amd64.deb
 install_libs intel-igc-opencl_${IGC_VER}~ppa1~bionic1_amd64.deb
+install_libs intel-gmmlib_${GMM_VER}~ppa1~bionic1_amd64.deb
+install_libs intel-gmmlib-dev_${GMM_VER}~ppa1~bionic1_amd64.deb
 
 cp -ar usr /
-ln -sf /usr/lib/x86_64-linux-gnu/*.so /usr/lib64
+ln -sf /usr/lib/x86_64-linux-gnu/*.so* /usr/lib64
 ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/*.pc /usr/lib64/pkgconfig
 mkdir /root/build
-


### PR DESCRIPTION
Use igc and gmmlib packages versions from fedora.spec.in to download
deb packages from launchpad.net.

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>