### PR TITLE
Avoid false-positive memory leak on reassign of global var

### DIFF
--- a/runtime/aub_mem_dump/aub_stream_stubs.cpp
+++ b/runtime/aub_mem_dump/aub_stream_stubs.cpp
@@ -22,7 +22,12 @@ AubManager *AubManager::create(uint32_t productFamily, uint32_t devicesCount, ui
 extern "C" {
 void injectMMIOList(MMIOList mmioList){};
 void setTbxServerPort(uint16_t port) { aub_stream_stubs::tbxServerPort = port; };
-void setTbxServerIp(std::string server) { aub_stream_stubs::tbxServerIp = server; };
+void setTbxServerIp(std::string server) {
+    // better to avoid reassigning global variables which assume memory allocations since
+    // we could step into false-positive memory leak detection with embedded leak check helper
+    if (aub_stream_stubs::tbxServerIp != server)
+        aub_stream_stubs::tbxServerIp = server;
+};
 }
 
 } // namespace aub_stream


### PR DESCRIPTION
We can step into false-positive memory leak if we reassign global variables
which assume memory allocations, for example std::string. Our unit tests has
embedded memory leak detector which gets inited/destroyed somewhere in the
middle of the test run. Hence allocations/deallocations done before/after its
active livetime will be transparent for it.

This particular case reassigned std::string global variable to the same value.
Apperantly my version of libstdc++ (the one on CentOS 7) did not recognize
that input/output string size is actually the same.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>