### PR TITLE
Add build on Ubuntu 18.04 with llvm 7

### DIFF
--- a/scripts/build-igc-llvm7.sh
+++ b/scripts/build-igc-llvm7.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (C) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+mkdir /root/build-igc
+cd /root/build-igc
+
+export cclang_commit_id=6257ffe137a2c8df95a3f3b39fa477aa8ed15837
+export spirv_id=8ce6443ec1020183eafaeb3410c7d1edc2355dc3
+export igc_commit_id=e8c547979dcc2113be74471479b7e630fff5db84
+
+wget --no-check-certificate https://github.com/intel/opencl-clang/archive/${cclang_commit_id}/opencl-clang.tar.gz
+wget --no-check-certificate https://github.com/intel/intel-graphics-compiler/archive/${igc_commit_id}/igc.tar.gz
+wget --no-check-certificate https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/${spirv_id}/spirv-llvm-translator.tar.gz
+
+mkdir igc common_clang llvm-spirv
+
+tar xzf opencl-clang.tar.gz -C common_clang --strip-components=1
+tar xzf igc.tar.gz -C igc --strip-components=1
+tar xzf spirv-llvm-translator.tar.gz -C llvm-spirv --strip-components=1
+
+mkdir build_spirv
+cd build_spirv
+cmake ../llvm-spirv -DCMAKE_INSTALL_PREFIX=install -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release
+make llvm-spirv -j`nproc`
+make install
+cd ..
+
+mkdir build_opencl_clang
+cd build_opencl_clang
+cmake -DCOMMON_CLANG_LIBRARY_NAME=opencl_clang -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../build_spirv/install -DLLVM_NO_DEAD_STRIP=ON -DCMAKE_INSTALL_PREFIX:PATH='/usr' ../common_clang
+make -j`nproc` all
+make install
+cd ..
+
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DIGC_OPTION__OUTPUT_DIR=../igc-install/Release -DVME_TYPES_DEFINED=FALSE -DCMAKE_INSTALL_PREFIX:PATH='/usr' -Wno-dev ../igc
+make -j`nproc`
+make install
+cd ..
+

--- a/scripts/build-ubuntu-18.4-llvm7-docker.sh
+++ b/scripts/build-ubuntu-18.4-llvm7-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (C) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+git fetch -t
+git clone ../compute-runtime neo
+docker build -f scripts/docker/Dockerfile-ubuntu-18.04-llvm-7 -t neo-ubuntu-18.4-llvm-7:ci .
+

--- a/scripts/docker/Dockerfile-ubuntu-18.04-llvm-7
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-llvm-7
@@ -1,0 +1,15 @@
+FROM docker.io/ubuntu:18.04
+MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
+
+COPY neo /root/neo
+COPY scripts/build-igc-llvm7.sh /root
+
+RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg cmake git pkg-config ninja-build clang-7 wget llvm-7-dev libclang-7-dev bison python2.7 flex python procps; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
+    apt-get -y update ; apt-get install -y --allow-unauthenticated intel-gmmlib-dev
+RUN /root/build-igc-llvm7.sh
+RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang-7 -DCMAKE_CXX_COMPILER=clang++-7 \
+    -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`
+CMD ["/bin/bash"]


### PR DESCRIPTION
- Neo is built with clang 7
- IGC components are built using llvm7
- gmmlib is downloaded from launchpad ppa

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>