### PR TITLE
libva revision update.

### DIFF
--- a/manifests/manifest.yml
+++ b/manifests/manifest.yml
@@ -35,7 +35,7 @@ components:
     clean_on_sync: true
     dest_dir: libva
     repository: https://github.com/intel/libva.git
-    revision: c9bb65b
+    revision: 25b3307
     type: git
   wdk:
     branch: wdk


### PR DESCRIPTION
The libva revision is really outdated. For users who depend on vaapi-OpenCL
buffer sharing, they may have to build all the projects by themselves,
which is painful. With up-to-date libva revision (2.4.0), people can just use
release packages directly.
This fixes #131.

Signed-off-by: Ruiling Song <ruiling.song@intel.com>