### PR TITLE
remove /usr/local/bin directory from rpm package

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -87,6 +87,7 @@ if(UNIX)
     /etc/ld.so.conf.d
     /usr/local
     /usr/local/lib64
+    /usr/local/bin
   )
 
   if(CMAKE_VERSION VERSION_GREATER 3.6 OR CMAKE_VERSION VERSION_EQUAL 3.6)


### PR DESCRIPTION
To resolve issue on Centos:
file /usr/local/bin from install of intel-ocloc-19.25.0-1.el7.x86_64
conflicts with file from package filesystem-3.2-25.el7.x86_64

Fix for: https://github.com/intel/compute-runtime/issues/183

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>