### PR TITLE
ci: update IGC builds on Semaphore CI

### DIFF
--- a/scripts/build-igc-llvm7.sh
+++ b/scripts/build-igc-llvm7.sh
@@ -10,7 +10,7 @@ cd /root/build-igc
 
 export cclang_commit_id=6257ffe137a2c8df95a3f3b39fa477aa8ed15837
 export spirv_id=8ce6443ec1020183eafaeb3410c7d1edc2355dc3
-export igc_commit_id=igc-1.0.8
+export igc_commit_id=296a42bdfa870011a26b0e3d0d7d8d8da3a9ddb7
 
 wget --no-check-certificate https://github.com/intel/opencl-clang/archive/${cclang_commit_id}/opencl-clang.tar.gz
 wget --no-check-certificate https://github.com/intel/intel-graphics-compiler/archive/${igc_commit_id}/igc.tar.gz
@@ -41,7 +41,7 @@ cd ..
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DIGC_OPTION__OUTPUT_DIR=../igc-install/Release -DCOMMON_CLANG_LIBRARY_NAME=opencl_clang -DVME_TYPES_DEFINED=FALSE -DCMAKE_INSTALL_PREFIX='/usr' -Wno-dev ../igc
-make -j`nproc`
+make -j 1
 make install
 cd ..
 

--- a/scripts/build-igc-llvm8.sh
+++ b/scripts/build-igc-llvm8.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright (C) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+mkdir /root/build-igc
+cd /root/build-igc
+
+export cclang_commit_id=41cad395859684b18e762ca4a2c713c2fa349622
+export spirv_id=83298e3c9b124486c16d0fde54c764a6c5a2b554
+export igc_commit_id=296a42bdfa870011a26b0e3d0d7d8d8da3a9ddb7
+
+wget --no-check-certificate https://github.com/intel/opencl-clang/archive/${cclang_commit_id}/opencl-clang.tar.gz
+wget --no-check-certificate https://github.com/intel/intel-graphics-compiler/archive/${igc_commit_id}/igc.tar.gz
+wget --no-check-certificate https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/${spirv_id}/spirv-llvm-translator.tar.gz
+
+mkdir igc opencl_clang llvm-spirv
+
+tar xzf opencl-clang.tar.gz -C opencl_clang --strip-components=1
+tar xzf igc.tar.gz -C igc --strip-components=1
+tar xzf spirv-llvm-translator.tar.gz -C llvm-spirv --strip-components=1
+
+pushd llvm-spirv
+dos2unix ../opencl_clang/patches/spirv/0001-Update-LowerOpenCL-pass-to-handle-new-blocks-represn.patch
+dos2unix ../opencl_clang/patches/spirv/0002-Translation-of-llvm.dbg.declare-in-case-the-local-va.patch
+
+patch -p1 < ../opencl_clang/patches/spirv/0001-Update-LowerOpenCL-pass-to-handle-new-blocks-represn.patch
+patch -p1 < ../opencl_clang/patches/spirv/0002-Translation-of-llvm.dbg.declare-in-case-the-local-va.patch
+popd
+
+mkdir build_spirv
+cd build_spirv
+cmake ../llvm-spirv -DCMAKE_INSTALL_PREFIX=install -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release
+make llvm-spirv -j`nproc`
+make install
+cd ..
+
+mkdir build_opencl_clang
+cd build_opencl_clang
+cmake -DCOMMON_CLANG_LIBRARY_NAME=opencl_clang -DLLVMSPIRV_INCLUDED_IN_LLVM=OFF -DSPIRV_TRANSLATOR_DIR=../build_spirv/install -DLLVM_NO_DEAD_STRIP=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/usr' ../opencl_clang
+make -j`nproc` all
+make install
+cd ..
+
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DIGC_OPTION__OUTPUT_DIR=../igc-install/Release -DCOMMON_CLANG_LIBRARY_NAME=opencl_clang \
+-DCMAKE_INSTALL_PREFIX='/usr' -Wno-dev ../igc -DIGC_PREFERRED_LLVM_VERSION=8.0.0
+make -j 1
+make install
+cd ..
+

--- a/scripts/build-ubuntu-18.4-llvm8-docker.sh
+++ b/scripts/build-ubuntu-18.4-llvm8-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (C) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+#
+
+git fetch -t
+git clone ../compute-runtime neo
+docker build -f scripts/docker/Dockerfile-ubuntu-18.04-llvm-8 -t neo-ubuntu-18.4-llvm-8:ci .
+

--- a/scripts/docker/Dockerfile-ubuntu-18.04-llvm-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-llvm-8
@@ -1,0 +1,15 @@
+FROM docker.io/ubuntu:18.04
+MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
+
+COPY neo /root/neo
+COPY scripts/build-igc-llvm8.sh /root
+
+RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg cmake git pkg-config ninja-build clang-8 wget llvm-8-dev libclang-8-dev bison python2.7 flex python procps dos2unix; \
+    echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
+    apt-get -y update ; apt-get install -y --allow-unauthenticated intel-gmmlib-dev
+RUN /root/build-igc-llvm8.sh
+RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 \
+    -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`
+CMD ["/bin/bash"]


### PR DESCRIPTION
- add build on Ubuntu 18.04 with llvm 8
    - Neo is built with clang 8
    - IGC components are built using llvm/clang 8
    - gmmlib is downloaded from launchpad ppa
- update IGC to 1.0.10-2314
- limit number of make jobs to 1 to avoid problems with
  "virtual memory exhausted: Cannot allocate memory" and to workaround
   compilation issue:
Scanning dependencies of target elf_packager
[19%] Building CXX object IGC/ElfPackager/CMakeFiles/elf_packager.dir/main.cpp.o
In file included from /root/build-igc/igc/IGC/ElfPackager/main.cpp:53:0:
/root/build-igc/igc/IGC/ElfPackager/../GenISAIntrinsics/GenIntrinsics.h:44:10:
 fatal error: IntrinsicGenISA.gen: No such file or directory
 #include "IntrinsicGenISA.gen"
          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>