### PR TITLE
ci: use intel-gmmlib from ppa in Semaphore build

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu-16.04-ppa-gcc-5
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-ppa-gcc-5
@@ -5,9 +5,8 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build intel-igc-opencl-dev
-RUN cd /root; git clone --depth 1 https://github.com/intel/gmmlib gmmlib
+    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build intel-igc-opencl-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 -DSKIP_UNIT_TESTS=1 ../neo; \
-    ninja -j `nproc`
+    ninja -j 2
 CMD ["/bin/bash"]


### PR DESCRIPTION
Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>