### PR TITLE
ci: use IGC 1.0.2597 in Semaphore CI builds

### DIFF
--- a/scripts/build-igc-llvm7.sh
+++ b/scripts/build-igc-llvm7.sh
@@ -10,7 +10,7 @@ cd /root/build-igc
 
 export cclang_commit_id=6257ffe137a2c8df95a3f3b39fa477aa8ed15837
 export spirv_id=8ce6443ec1020183eafaeb3410c7d1edc2355dc3
-export igc_commit_id=7c89d200bf9c5b5900d961bc6f7df5373f3d0ab6
+export igc_commit_id=b3ed5e584dac45d560e6f68e5f6e84af8a661e6e
 
 wget --no-check-certificate https://github.com/intel/opencl-clang/archive/${cclang_commit_id}/opencl-clang.tar.gz
 wget --no-check-certificate https://github.com/intel/intel-graphics-compiler/archive/${igc_commit_id}/igc.tar.gz

--- a/scripts/build-igc-llvm8.sh
+++ b/scripts/build-igc-llvm8.sh
@@ -10,7 +10,7 @@ cd /root/build-igc
 
 export cclang_commit_id=41cad395859684b18e762ca4a2c713c2fa349622
 export spirv_id=83298e3c9b124486c16d0fde54c764a6c5a2b554
-export igc_commit_id=7c89d200bf9c5b5900d961bc6f7df5373f3d0ab6
+export igc_commit_id=b3ed5e584dac45d560e6f68e5f6e84af8a661e6e
 
 wget --no-check-certificate https://github.com/intel/opencl-clang/archive/${cclang_commit_id}/opencl-clang.tar.gz
 wget --no-check-certificate https://github.com/intel/intel-graphics-compiler/archive/${igc_commit_id}/igc.tar.gz


### PR DESCRIPTION
There are 2 builds on Semaphore CI under Ubuntu 18.04
with llvm 7 and llvm 8.

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>