### PR TITLE
I915_CONTEXT_PARAM_PERSISTENCE support

### DIFF
--- a/runtime/os_interface/linux/drm_neo.cpp
+++ b/runtime/os_interface/linux/drm_neo.cpp
@@ -174,10 +174,20 @@ bool Drm::setQueueSliceCount(uint64_t sliceCount) {
     return false;
 }
 
+void Drm::setNonPersistent(uint32_t drmContextId) {
+    drm_i915_gem_context_param contextParam = {};
+    contextParam.ctx_id = drmContextId;
+    contextParam.param = I915_CONTEXT_PARAM_PERSISTENCE;
+
+    ioctl(DRM_IOCTL_I915_GEM_CONTEXT_SETPARAM, &contextParam);
+}
+
 uint32_t Drm::createDrmContext() {
     drm_i915_gem_context_create gcc = {};
     auto retVal = ioctl(DRM_IOCTL_I915_GEM_CONTEXT_CREATE, &gcc);
     UNRECOVERABLE_IF(retVal != 0);
+
+    setNonPersistent(gcc.ctx_id);
 
     return gcc.ctx_id;
 }

--- a/runtime/os_interface/linux/drm_neo.h
+++ b/runtime/os_interface/linux/drm_neo.h
@@ -89,6 +89,7 @@ class Drm {
 
   protected:
     int getQueueSliceCount(drm_i915_gem_context_param_sseu *sseu);
+    void setNonPersistent(uint32_t drmContextId);
     bool sliceCountChangeSupported = false;
     drm_i915_gem_context_param_sseu sseu{};
     bool preemptionSupported = false;

--- a/third_party/uapi/drm/i915_drm.h
+++ b/third_party/uapi/drm/i915_drm.h
@@ -1513,6 +1513,8 @@ struct drm_i915_gem_context_param {
 	 */
 #define I915_CONTEXT_PARAM_SSEU		0x7
 
+#define I915_CONTEXT_PARAM_PERSISTENCE 0xb
+
 /*
  * Not all clients may want to attempt automatic recover of a context after
  * a hang (for example, some clients may only submit very small incremental

--- a/unit_tests/os_interface/linux/device_command_stream_fixture.h
+++ b/unit_tests/os_interface/linux/device_command_stream_fixture.h
@@ -274,6 +274,9 @@ class DrmMockCustom : public Drm {
             *getParam->value = getParamRetValue;
         } break;
 
+        case DRM_IOCTL_I915_GEM_CONTEXT_SETPARAM: {
+        } break;
+
         case DRM_IOCTL_I915_GEM_CONTEXT_GETPARAM: {
             ioctl_cnt.contextGetParam++;
             auto getContextParam = (drm_i915_gem_context_param *)arg;

--- a/unit_tests/os_interface/linux/drm_mock.cpp
+++ b/unit_tests/os_interface/linux/drm_mock.cpp
@@ -85,6 +85,9 @@ int DrmMock::ioctl(unsigned long request, void *arg) {
             }
             return this->StoredRetValForSetSSEU;
         }
+        if (receivedContextParamRequest.param == I915_CONTEXT_PARAM_PERSISTENCE) {
+            return 0;
+        }
     }
 
     if ((request == DRM_IOCTL_I915_GEM_CONTEXT_GETPARAM) && (arg != nullptr)) {

--- a/unit_tests/os_interface/linux/drm_tests.cpp
+++ b/unit_tests/os_interface/linux/drm_tests.cpp
@@ -195,7 +195,7 @@ TEST(DrmTest, givenDrmWhenOsContextIsCreatedThenCreateAndDestroyNewDrmOsContext)
     }
 
     EXPECT_EQ(drmContextId1, drmMock.receivedDestroyContextId);
-    EXPECT_EQ(0u, drmMock.receivedContextParamRequestCount);
+    EXPECT_EQ(2u, drmMock.receivedContextParamRequestCount);
 }
 
 TEST(DrmTest, givenDrmPreemptionEnabledAndLowPriorityEngineWhenCreatingOsContextThenCallSetContextPriorityIoctl) {
@@ -206,15 +206,15 @@ TEST(DrmTest, givenDrmPreemptionEnabledAndLowPriorityEngineWhenCreatingOsContext
     OsContextLinux osContext1(drmMock, 0u, 1, aub_stream::ENGINE_RCS, PreemptionMode::Disabled, false);
     OsContextLinux osContext2(drmMock, 0u, 1, aub_stream::ENGINE_RCS, PreemptionMode::Disabled, true);
 
-    EXPECT_EQ(0u, drmMock.receivedContextParamRequestCount);
+    EXPECT_EQ(2u, drmMock.receivedContextParamRequestCount);
 
     drmMock.preemptionSupported = true;
 
     OsContextLinux osContext3(drmMock, 0u, 1, aub_stream::ENGINE_RCS, PreemptionMode::Disabled, false);
-    EXPECT_EQ(0u, drmMock.receivedContextParamRequestCount);
+    EXPECT_EQ(3u, drmMock.receivedContextParamRequestCount);
 
     OsContextLinux osContext4(drmMock, 0u, 1, aub_stream::ENGINE_RCS, PreemptionMode::Disabled, true);
-    EXPECT_EQ(1u, drmMock.receivedContextParamRequestCount);
+    EXPECT_EQ(5u, drmMock.receivedContextParamRequestCount);
     EXPECT_EQ(drmMock.StoredCtxId, drmMock.receivedContextParamRequest.ctx_id);
     EXPECT_EQ(static_cast<uint64_t>(I915_CONTEXT_PARAM_PRIORITY), drmMock.receivedContextParamRequest.param);
     EXPECT_EQ(static_cast<uint64_t>(-1023), drmMock.receivedContextParamRequest.value);


### PR DESCRIPTION
Add new IOCTL call to disable persistence on given context

Signed-off-by: Dunajski, Bartosz <bartosz.dunajski@intel.com>