### PR TITLE
ci: limit number of ninja jobs to 2

### DIFF
--- a/scripts/docker/Dockerfile-arch
+++ b/scripts/docker/Dockerfile-arch
@@ -8,5 +8,5 @@ RUN /root/prepare-arch.sh
 RUN cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DDO_NOT_RUN_AUB_TESTS=1 ../neo ; \
-    ninja -j `nproc`
+    ninja -j 2
 CMD ["/bin/bash"]


### PR DESCRIPTION
to avoid issue on Semaphore during Arch build with gcc

[880/1712] Building CXX object unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o
FAILED: unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o
/usr/sbin/g++    @unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o.rsp -MD -MT unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o -MF unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o.d -o unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o -c /root/neo/unit_tests/api/api_tests_wrapper3.cpp
g++: fatal error: Killed signal terminated program cc1plus
compilation terminated.


Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>