### PR TITLE
ci: limit number on make jobs on Semaphore

### DIFF
--- a/scripts/docker/Dockerfile-fedora-30-copr
+++ b/scripts/docker/Dockerfile-fedora-30-copr
@@ -11,5 +11,5 @@ RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
     dnf install -y intel-igc-opencl-devel intel-gmmlib-devel; \
     mkdir /root/build; cd /root/build ; cmake -G Ninja \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo; \
-    ninja -j `nproc`
+    ninja -j 2
 CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile-fedora-31-copr
+++ b/scripts/docker/Dockerfile-fedora-31-copr
@@ -11,5 +11,5 @@ RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
     dnf install -y intel-igc-opencl-devel intel-gmmlib-devel; \
     mkdir /root/build; cd /root/build ; cmake -G Ninja \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo; \
-    ninja -j `nproc`
+    ninja -j 2
 CMD ["/bin/bash"]


### PR DESCRIPTION
to avoid error:
FAILED: unit_tests/CMakeFiles/igdrcl_tests.dir/api/api_tests_wrapper3.cpp.o
c++: fatal error: Killed signal terminated program cc1plus
compilation terminated.

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>