### PR TITLE
ci: don't build unit tests on Shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -7,7 +7,7 @@ build:
     - mkdir workspace; cd workspace
     - git clone ../../compute-runtime neo
     - mkdir build; cd build
-    - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ../neo
+    - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DSKIP_UNIT_TESTS=1 ../neo
     - ninja
 integrations:
     notifications:


### PR DESCRIPTION
- to avoid timeouts, as build timeout is 1 hour

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>