### PR TITLE
linker.cpp: fix for missing RelocationInfo.h

### DIFF
--- a/core/compiler_interface/linker.cpp
+++ b/core/compiler_interface/linker.cpp
@@ -11,7 +11,7 @@
 #include "core/helpers/debug_helpers.h"
 #include "core/helpers/ptr_math.h"
 
-#include "RelocationInfo.h"
+#include "visa/RelocationInfo.h"
 
 #include <sstream>
 

--- a/core/unit_tests/compiler_interface/linker_tests.cpp
+++ b/core/unit_tests/compiler_interface/linker_tests.cpp
@@ -7,7 +7,7 @@
 
 #include "core/helpers/ptr_math.h"
 
-#include "RelocationInfo.h"
+#include "visa/RelocationInfo.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "linker_mock.h"

--- a/core/unit_tests/program/program_info_from_patchtokens_tests.cpp
+++ b/core/unit_tests/program/program_info_from_patchtokens_tests.cpp
@@ -13,7 +13,7 @@
 #include "core/unit_tests/device_binary_format/patchtokens_tests.h"
 #include "runtime/program/kernel_info.h"
 
-#include "RelocationInfo.h"
+#include "visa/RelocationInfo.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Facing build failure with below error:

git/core/compiler_interface/linker.cpp:14:10: fatal error: RelocationInfo.h: No such file or directory
|    14 | #include "RelocationInfo.h"
|       |          ^~~~~~~~~~~~~~~~~~
| compilation terminated.

igc provides RelocationInfo.h header at /usr/include/visa/

Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>