### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,7 +7,7 @@ Instructions have been tested on Ubuntu* and CentOS*. They assume a clean instal
 Example (Ubuntu):
 
 ```shell
-sudo apt-get install cmake g++ git pkg-config
+sudo apt-get --no-install-recommends install cmake g++ git pkg-config
 ```
 
 Example (CentOS):

--- a/DISTRIBUTIONS.md
+++ b/DISTRIBUTIONS.md
@@ -75,13 +75,13 @@ ipoldek install intel-gmmlib intel-graphics-compiler intel-compute-runtime
 ```
 add-apt-repository ppa:intel-opencl/intel-opencl
 apt-get update
-apt-get install intel-opencl-icd
+apt-get --no-install-recommends install intel-opencl-icd
 ```
 
 ## Ubuntu* 19.04, 19.10, 20.04
 
 ```
-apt-get install intel-opencl-icd
+apt-get --no-install-recommends install intel-opencl-icd
 ```
 
 ## Packages mirror

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and can be installed via the distro's package manager.
 For example on Ubuntu* 19.04, 19.10:
 
 ```
-apt-get install intel-opencl-icd
+apt-get --no-install-recommends install intel-opencl-icd
 ```
 
 Procedures for other

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-11
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-12
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-8
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-5-gen-9
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-4
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-4
@@ -3,10 +3,10 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-4.0
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-4.0
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-4.0 -DCMAKE_CXX_COMPILER=clang++-4.0 \
     ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-5
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-5
@@ -3,10 +3,10 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-5.0
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-5.0
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 \
     ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-6
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-6
@@ -3,10 +3,10 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-6.0
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-6.0
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 \
      ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-7
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-7
@@ -3,10 +3,10 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-7
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-7
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-7 -DCMAKE_CXX_COMPILER=clang++-7 \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-8
@@ -3,12 +3,12 @@ MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg wget; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg wget; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" >> /etc/apt/sources.list; \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |  apt-key add - ; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-8
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake git pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-8
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-11
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-12
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-8
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-5-gen-9
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-5 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-5 -DCMAKE_CXX_COMPILER=g++-5 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-11
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-12
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \
     -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-8
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-6-gen-9
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-6 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc-6 -DCMAKE_CXX_COMPILER=g++-6 ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-11
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-12
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-8
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-7-gen-9
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 MAINTAINER Jacek Danecki <jacek.danecki@intel.com>
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++-7 git pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -22,11 +22,11 @@ then
 	apt-get -y update
 fi
 
-apt-get install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
+apt-get --no-install-recommends install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
 if [ $? -ne 0 ]
 then
 	wait_apt
-	apt-get install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
+	apt-get --no-install-recommends install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
 fi
 
 dpkg -r ccache


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>