### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-11
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-12
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-8
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-16.04-gcc-gen-9
@@ -5,7 +5,7 @@ COPY neo /root/neo
 
 RUN echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu xenial main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ../neo; \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-clang-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-clang-8
@@ -3,10 +3,10 @@ LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg wget; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-8
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake pkg-config ninja-build libigc-dev intel-gmmlib-dev clang-8
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-11
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-12
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-8
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-18.04-gcc-gen-9
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:18.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu bionic main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-19.10-clang
+++ b/scripts/docker/Dockerfile-ubuntu-19.10-clang
@@ -3,10 +3,10 @@ LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg wget; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu eoan main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake pkg-config ninja-build libigc-dev intel-gmmlib-dev clang
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake pkg-config ninja-build libigc-dev intel-gmmlib-dev clang
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-11
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:19.10
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu eoan main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-12
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:19.10
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu eoan main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \

--- a/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-8
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:19.10
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu eoan main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-19.10-gcc-gen-9
@@ -2,10 +2,10 @@ FROM docker.io/ubuntu:19.10
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu eoan main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-clang
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-clang
@@ -3,11 +3,11 @@ LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
 
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg wget; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake pkg-config ninja-build libigc-dev intel-gmmlib-dev \
-    clang libstdc++-10-dev 
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake pkg-config \
+    ninja-build libigc-dev intel-gmmlib-dev clang libstdc++-10-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo ; ninja -j `nproc`

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
@@ -2,10 +2,11 @@ FROM docker.io/ubuntu:20.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
@@ -2,10 +2,11 @@ FROM docker.io/ubuntu:20.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
@@ -2,10 +2,11 @@ FROM docker.io/ubuntu:20.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
@@ -2,10 +2,11 @@ FROM docker.io/ubuntu:20.04
 LABEL maintainer="jacek.danecki@intel.com"
 
 COPY neo /root/neo
-RUN apt-get -y update ; apt-get install -y --allow-unauthenticated gpg; \
+RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get install -y --allow-unauthenticated cmake g++ pkg-config ninja-build libigc-dev intel-gmmlib-dev
+    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2018-2019 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 #
@@ -22,11 +22,11 @@ then
 	apt-get -y update
 fi
 
-apt-get install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
+apt-get --no-install-recommends install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
 if [ $? -ne 0 ]
 then
 	wait_apt
-	apt-get install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
+	apt-get --no-install-recommends install -y --allow-unauthenticated cmake ninja-build libigc-dev intel-gmmlib-dev
 fi
 
 dpkg -r ccache


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs
recommended but not suggested packages.

By passing "--no-install-recommends" option, the user lets apt-get know
not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

https://github.com/intel/compute-runtime/pull/268

Change-Id: I5a5de36102c5d3d3a42def30404078c485705b8a