### PR TITLE
ci: set noninteractive frontend on Ubuntu 20.04

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu-20.04-clang
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-clang
@@ -6,7 +6,7 @@ COPY neo /root/neo
 RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake pkg-config \
+    apt-get -y update ; DEBIAN_FRONTEND="noninteractive" apt-get --no-install-recommends install -y --allow-unauthenticated cmake pkg-config \
     ninja-build libigc-dev intel-gmmlib-dev clang libstdc++-10-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
@@ -5,7 +5,7 @@ COPY neo /root/neo
 RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    apt-get -y update ; DEBIAN_FRONTEND="noninteractive" apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
     pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
@@ -5,7 +5,7 @@ COPY neo /root/neo
 RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    apt-get -y update ; DEBIAN_FRONTEND="noninteractive" apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
     pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
@@ -5,7 +5,7 @@ COPY neo /root/neo
 RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    apt-get -y update ; DEBIAN_FRONTEND="noninteractive" apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
     pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
@@ -5,7 +5,7 @@ COPY neo /root/neo
 RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated gpg dirmngr gpg-agent; \
     echo "deb http://ppa.launchpad.net/ocl-dev/intel-opencl/ubuntu focal main" >> /etc/apt/sources.list; \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C3086B78CC05B8B1; \
-    apt-get -y update ; apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
+    apt-get -y update ; DEBIAN_FRONTEND="noninteractive" apt-get --no-install-recommends install -y --allow-unauthenticated cmake g++ \
     pkg-config ninja-build libigc-dev intel-gmmlib-dev
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \


### PR DESCRIPTION
- to install tzdata on Travis

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>