### PR TITLE
ci: limit number ninja jobs to 1

### DIFF
--- a/scripts/docker/Dockerfile-fedora-32-copr
+++ b/scripts/docker/Dockerfile-fedora-32-copr
@@ -11,5 +11,5 @@ RUN dnf install -y gcc-c++ cmake ninja-build git pkg-config; \
     dnf install -y intel-igc-opencl-devel intel-gmmlib-devel; \
     mkdir /root/build; cd /root/build ; cmake -G Ninja \
     -DDO_NOT_RUN_AUB_TESTS=1 -DDONT_CARE_OF_VIRTUALS=1 ../neo; \
-    ninja -j 2
+    ninja -j 1
 CMD ["/bin/bash"]


### PR DESCRIPTION
on Fedora 32 on Semaphore CI to workaround memory limit

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>