### PR TITLE
use libdrm directory instead of drm

### DIFF
--- a/opencl/source/sharings/va/va_surface.cpp
+++ b/opencl/source/sharings/va/va_surface.cpp
@@ -15,7 +15,7 @@
 #include "opencl/source/context/context.h"
 #include "opencl/source/mem_obj/image.h"
 
-#include <drm/drm_fourcc.h>
+#include <libdrm/drm_fourcc.h>
 #include <va/va_drmcommon.h>
 
 namespace NEO {

--- a/opencl/test/unit_test/sharings/va/mock_va_sharing.h
+++ b/opencl/test/unit_test/sharings/va/mock_va_sharing.h
@@ -10,7 +10,7 @@
 
 #include "opencl/source/sharings/va/va_sharing.h"
 
-#include <drm/drm_fourcc.h>
+#include <libdrm/drm_fourcc.h>
 #include <va/va_drmcommon.h>
 
 namespace NEO {


### PR DESCRIPTION
drm headers are in /usr/include/libdrm under Arch Linux
See discussion in https://github.com/intel/gstreamer-media-SDK/issues/121

Signed-off-by: Jacek Danecki <jacek.danecki@intel.com>