### PR TITLE
Don't use VM when ppGTT is invalid/unassigned

### DIFF
--- a/shared/source/os_interface/linux/drm_query.cpp
+++ b/shared/source/os_interface/linux/drm_query.cpp
@@ -49,6 +49,10 @@ int Drm::createDrmVirtualMemory(uint32_t &drmVmId) {
     drm_i915_gem_vm_control ctl = {};
     auto ret = SysCalls::ioctl(getFileDescriptor(), DRM_IOCTL_I915_GEM_VM_CREATE, &ctl);
     if (ret == 0) {
+        if (ctl.vm_id == 0) {
+            // 0 is reserved for invalid/unassigned ppgtt
+            return -1;
+        }
         drmVmId = ctl.vm_id;
     }
     return ret;

--- a/shared/source/os_interface/linux/drm_query_exp.cpp
+++ b/shared/source/os_interface/linux/drm_query_exp.cpp
@@ -86,6 +86,10 @@ int Drm::createDrmVirtualMemory(uint32_t &drmVmId) {
     drm_i915_gem_vm_control ctl = {};
     auto ret = SysCalls::ioctl(getFileDescriptor(), DRM_IOCTL_I915_GEM_VM_CREATE, &ctl);
     if (ret == 0) {
+        if (ctl.vm_id == 0) {
+            // 0 is reserved for invalid/unassigned ppgtt
+            return -1;
+        }
         drmVmId = ctl.vm_id;
     }
     return ret;


### PR DESCRIPTION
VM wasn't ported on FreeBSD but "create" ioctl succeeds, confusing NEO whether VM can be used.

https://github.com/freebsd/drm-kmod/issues/24
