### PR TITLE
Add cl_intel_pci_bus_info extension

### DIFF
--- a/opencl/extensions/public/cl_ext_private.h
+++ b/opencl/extensions/public/cl_ext_private.h
@@ -210,3 +210,18 @@ typedef cl_bitfield cl_device_feature_capabilities_intel;
 
 /* For GPU devices, version 1.0.0: */
 #define CL_DEVICE_FEATURE_FLAG_DP4A_INTEL (1 << 0)
+
+/****************************************
+ * cl_khr_pci_bus_info extension *
+ ***************************************/
+#define cl_khr_pci_bus_info 1
+
+// New queries for clGetDeviceInfo:
+#define CL_DEVICE_PCI_BUS_INFO_KHR 0x410F
+
+typedef struct _cl_device_pci_bus_info_khr {
+    cl_uint pci_domain;
+    cl_uint pci_bus;
+    cl_uint pci_device;
+    cl_uint pci_function;
+} cl_device_pci_bus_info_khr;

--- a/opencl/source/cl_device/cl_device.cpp
+++ b/opencl/source/cl_device/cl_device.cpp
@@ -263,4 +263,9 @@ void ClDevice::getQueueFamilyName(char *outputName, size_t maxOutputNameLength, 
 Platform *ClDevice::getPlatform() const {
     return castToObject<Platform>(platformId);
 }
+bool ClDevice::isPciBusInfoValid() const {
+    return deviceInfo.pciBusInfo.pci_domain != PhysicalDevicePciBusInfo::InvalidValue && deviceInfo.pciBusInfo.pci_bus != PhysicalDevicePciBusInfo::InvalidValue &&
+           deviceInfo.pciBusInfo.pci_device != PhysicalDevicePciBusInfo::InvalidValue && deviceInfo.pciBusInfo.pci_function != PhysicalDevicePciBusInfo::InvalidValue;
+}
+
 } // namespace NEO

--- a/opencl/source/cl_device/cl_device.h
+++ b/opencl/source/cl_device/cl_device.h
@@ -121,6 +121,7 @@ class ClDevice : public BaseObject<_cl_device_id> {
     DeviceBitfield getDeviceBitfield() const;
     bool isDeviceEnqueueSupported() const;
     bool arePipesSupported() const;
+    bool isPciBusInfoValid() const;
 
     static cl_command_queue_capabilities_intel getQueueFamilyCapabilitiesAll();
     MOCKABLE_VIRTUAL cl_command_queue_capabilities_intel getQueueFamilyCapabilities(EngineGroupType type);

--- a/opencl/source/cl_device/cl_device_caps.cpp
+++ b/opencl/source/cl_device/cl_device_caps.cpp
@@ -202,6 +202,21 @@ void ClDevice::initializeCaps() {
         deviceExtensions += sharingFactory.getExtensions(driverInfo.get());
     }
 
+    PhysicalDevicePciBusInfo pciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue);
+
+    if (driverInfo) {
+        pciBusInfo = driverInfo->getPciBusInfo();
+    }
+
+    deviceInfo.pciBusInfo.pci_domain = pciBusInfo.pciDomain;
+    deviceInfo.pciBusInfo.pci_bus = pciBusInfo.pciBus;
+    deviceInfo.pciBusInfo.pci_device = pciBusInfo.pciDevice;
+    deviceInfo.pciBusInfo.pci_function = pciBusInfo.pciFunction;
+
+    if (isPciBusInfoValid()) {
+        deviceExtensions += "cl_khr_pci_bus_info ";
+    }
+
     deviceExtensions += hwHelper.getExtensions();
     deviceInfo.deviceExtensions = deviceExtensions.c_str();
 

--- a/opencl/source/cl_device/cl_device_info.cpp
+++ b/opencl/source/cl_device/cl_device_info.cpp
@@ -286,6 +286,12 @@ cl_int ClDevice::getDeviceInfo(cl_device_info paramName,
         retSize = srcSize = sizeof(cl_device_feature_capabilities_intel);
         break;
     }
+    case CL_DEVICE_PCI_BUS_INFO_KHR:
+        if (isPciBusInfoValid()) {
+            src = &deviceInfo.pciBusInfo;
+            retSize = srcSize = sizeof(deviceInfo.pciBusInfo);
+        }
+        break;
     default:
         if (getDeviceInfoForImage(paramName, src, srcSize, retSize) && !getSharedDeviceInfo().imageSupport) {
             src = &value;

--- a/opencl/source/cl_device/cl_device_info.h
+++ b/opencl/source/cl_device/cl_device_info.h
@@ -129,6 +129,7 @@ struct ClDeviceInfo {
     cl_uint                                                                                           internalDriverVersion;
     cl_uint                                                                                           grfSize;
     bool                                                                                              preemptionSupported;
+    cl_device_pci_bus_info_khr                                                                        pciBusInfo;
     /* Extensions supported */
     bool                                                                                              nv12Extension;
     bool                                                                                              vmeExtension;

--- a/opencl/test/unit_test/linux/mock_os_layer.cpp
+++ b/opencl/test/unit_test/linux/mock_os_layer.cpp
@@ -102,16 +102,18 @@ DIR *opendir(const char *name) {
 int closedir(DIR *dirp) {
     return 0u;
 }
-uint32_t entryIndex = 0u;
-const uint32_t numEntries = 4u;
 
 struct dirent entries[] = {
     {0, 0, 0, 0, "."},
     {0, 0, 0, 0, "pci-0000:test1-render"},
     {0, 0, 0, 0, "pci-0000:test2-render"},
     {0, 0, 0, 0, "pci-0000:1234-render"},
-
+    {0, 0, 0, 0, "pci-0000:0:2.1-render"},
+    {0, 0, 0, 0, "pci-0000:3:0.0-render"},
 };
+
+uint32_t entryIndex = 0u;
+const uint32_t numEntries = sizeof(entries) / sizeof(entries[0]);
 
 struct dirent *readdir(DIR *dir) {
     if (entryIndex >= numEntries) {

--- a/opencl/test/unit_test/os_interface/windows/driver_info_tests.cpp
+++ b/opencl/test/unit_test/os_interface/windows/driver_info_tests.cpp
@@ -83,7 +83,7 @@ class MockDriverInfoWindows : public DriverInfoWindows {
 
     static MockDriverInfoWindows *create(std::string path) {
 
-        auto result = new MockDriverInfoWindows("");
+        auto result = new MockDriverInfoWindows("", PhysicalDevicePciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue));
         result->reader = new TestedRegistryReader(path);
         result->registryReader.reset(result->reader);
 
@@ -152,7 +152,7 @@ struct DriverInfoWindowsTest : public ::testing::Test {
         DriverInfoWindows::createRegistryReaderFunc = [](const std::string &) -> std::unique_ptr<SettingsReader> {
             return std::make_unique<MockRegistryReader>();
         };
-        driverInfo = std::make_unique<MockDriverInfoWindows>("");
+        driverInfo = std::make_unique<MockDriverInfoWindows>("", PhysicalDevicePciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue));
     }
 
     VariableBackup<decltype(DriverInfoWindows::createRegistryReaderFunc)> createFuncBackup{&DriverInfoWindows::createRegistryReaderFunc};
@@ -178,7 +178,7 @@ TEST_F(DriverInfoWindowsTest, GivenDriverInfoWhenThenReturnNonNullptr) {
 };
 
 TEST(DriverInfo, givenDriverInfoWhenGetStringReturnNotMeaningEmptyStringThenEnableSharingSupport) {
-    MockDriverInfoWindows driverInfo("");
+    MockDriverInfoWindows driverInfo("", PhysicalDevicePciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue));
     MockRegistryReader *registryReaderMock = new MockRegistryReader();
 
     driverInfo.registryReader.reset(registryReaderMock);
@@ -190,7 +190,7 @@ TEST(DriverInfo, givenDriverInfoWhenGetStringReturnNotMeaningEmptyStringThenEnab
 };
 
 TEST(DriverInfo, givenDriverInfoWhenGetStringReturnMeaningEmptyStringThenDisableSharingSupport) {
-    MockDriverInfoWindows driverInfo("");
+    MockDriverInfoWindows driverInfo("", PhysicalDevicePciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue));
     MockRegistryReader *registryReaderMock = new MockRegistryReader();
     registryReaderMock->returnString = "<>";
     driverInfo.registryReader.reset(registryReaderMock);
@@ -206,7 +206,7 @@ TEST(DriverInfo, givenFullPathToRegistryWhenCreatingDriverInfoWindowsThenTheRegi
     std::string registryPath = "Path\\In\\Registry";
     std::string fullRegistryPath = "\\REGISTRY\\MACHINE\\" + registryPath;
     std::string expectedTrimmedRegistryPath = registryPath;
-    MockDriverInfoWindows driverInfo(std::move(fullRegistryPath));
+    MockDriverInfoWindows driverInfo(std::move(fullRegistryPath), PhysicalDevicePciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue));
 
     EXPECT_STREQ(expectedTrimmedRegistryPath.c_str(), driverInfo.path.c_str());
 };

--- a/shared/source/os_interface/driver_info.h
+++ b/shared/source/os_interface/driver_info.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <limits>
 #include <string>
 
 namespace NEO {
@@ -14,9 +16,24 @@ namespace NEO {
 struct HardwareInfo;
 class OSInterface;
 
+struct PhysicalDevicePciBusInfo {
+    PhysicalDevicePciBusInfo(uint32_t domain, uint32_t bus, uint32_t device, uint32_t function)
+        : pciDomain(domain), pciBus(bus), pciDevice(device), pciFunction(function) {}
+
+    uint32_t pciDomain;
+    uint32_t pciBus;
+    uint32_t pciDevice;
+    uint32_t pciFunction;
+
+    static const uint32_t InvalidValue = std::numeric_limits<uint32_t>::max();
+};
+
 class DriverInfo {
   public:
-    static DriverInfo *create(const HardwareInfo *hwInfo, OSInterface *osInterface);
+    DriverInfo()
+        : pciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue) {}
+
+    static DriverInfo *create(const HardwareInfo *hwInfo, const OSInterface *osInterface);
 
     virtual ~DriverInfo() = default;
 
@@ -24,6 +41,10 @@ class DriverInfo {
     virtual std::string getVersion(std::string defaultVersion) { return defaultVersion; }
     virtual bool getMediaSharingSupport() { return true; }
     virtual bool getImageSupport() { return true; }
+    virtual PhysicalDevicePciBusInfo getPciBusInfo() { return pciBusInfo; }
+
+  protected:
+    PhysicalDevicePciBusInfo pciBusInfo;
 };
 
 } // namespace NEO

--- a/shared/source/os_interface/linux/driver_info_linux.cpp
+++ b/shared/source/os_interface/linux/driver_info_linux.cpp
@@ -7,19 +7,35 @@
 
 #include "shared/source/os_interface/linux/driver_info_linux.h"
 
+#include "shared/source/helpers/debug_helpers.h"
 #include "shared/source/helpers/hw_info.h"
+#include "shared/source/os_interface/linux/drm_neo.h"
+#include "shared/source/os_interface/linux/os_interface.h"
 
 namespace NEO {
 
-DriverInfo *DriverInfo::create(const HardwareInfo *hwInfo, OSInterface *osInterface) {
+DriverInfo *DriverInfo::create(const HardwareInfo *hwInfo, const OSInterface *osInterface) {
+    PhysicalDevicePciBusInfo pciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue);
+    if (osInterface) {
+        auto osInterfaceImpl = osInterface->get();
+        UNRECOVERABLE_IF(osInterfaceImpl == nullptr);
+
+        auto drm = osInterface->get()->getDrm();
+        UNRECOVERABLE_IF(drm == nullptr);
+
+        pciBusInfo = drm->getPciBusInfo();
+    }
     if (hwInfo) {
         auto imageSupport = hwInfo->capabilityTable.supportsImages;
-        return new DriverInfoLinux(imageSupport);
+        return new DriverInfoLinux(imageSupport, pciBusInfo);
     }
     return nullptr;
 };
 
-DriverInfoLinux::DriverInfoLinux(bool imageSupport) : imageSupport(imageSupport) {}
+DriverInfoLinux::DriverInfoLinux(bool imageSupport, const PhysicalDevicePciBusInfo &pciBusInfo)
+    : imageSupport(imageSupport) {
+    this->pciBusInfo = pciBusInfo;
+}
 
 bool DriverInfoLinux::getImageSupport() { return imageSupport; }
 

--- a/shared/source/os_interface/linux/driver_info_linux.h
+++ b/shared/source/os_interface/linux/driver_info_linux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Intel Corporation
+ * Copyright (C) 2020-2021 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -13,7 +13,7 @@ namespace NEO {
 
 class DriverInfoLinux : public DriverInfo {
   public:
-    DriverInfoLinux(bool imageSupport);
+    DriverInfoLinux(bool imageSupport, const PhysicalDevicePciBusInfo &pciBusInfo);
     bool getImageSupport() override;
 
   protected:

--- a/shared/source/os_interface/linux/drm_neo.cpp
+++ b/shared/source/os_interface/linux/drm_neo.cpp
@@ -15,6 +15,7 @@
 #include "shared/source/helpers/hw_helper.h"
 #include "shared/source/helpers/hw_info.h"
 #include "shared/source/helpers/ptr_math.h"
+#include "shared/source/os_interface/driver_info.h"
 #include "shared/source/os_interface/linux/hw_device_id.h"
 #include "shared/source/os_interface/linux/os_inc.h"
 #include "shared/source/os_interface/linux/os_interface.h"
@@ -691,6 +692,21 @@ bool Drm::translateTopologyInfo(const drm_i915_query_topology_info *queryTopolog
     data.maxSubSliceCount = maxSubSliceCountPerSlice;
 
     return (data.sliceCount && data.subSliceCount && data.euCount);
+}
+
+PhysicalDevicePciBusInfo Drm::getPciBusInfo() const {
+    PhysicalDevicePciBusInfo pciBusInfo(PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue, PhysicalDevicePciBusInfo::InvalidValue);
+
+    UNRECOVERABLE_IF(hwDeviceId == nullptr);
+
+    const int pciBusInfoTokensNum = 3;
+    pciBusInfo.pciDomain = 0;
+
+    if (std::sscanf(hwDeviceId->getPciPath(), "%02x:%02x.%01x", &(pciBusInfo.pciBus), &(pciBusInfo.pciDevice), &(pciBusInfo.pciFunction)) != pciBusInfoTokensNum) {
+        pciBusInfo.pciDomain = pciBusInfo.pciBus = pciBusInfo.pciDevice = pciBusInfo.pciFunction = PhysicalDevicePciBusInfo::InvalidValue;
+    }
+
+    return pciBusInfo;
 }
 
 Drm::~Drm() {

--- a/shared/source/os_interface/linux/drm_neo.h
+++ b/shared/source/os_interface/linux/drm_neo.h
@@ -8,6 +8,7 @@
 #pragma once
 #include "shared/source/gmm_helper/gmm_lib.h"
 #include "shared/source/helpers/basic_math.h"
+#include "shared/source/os_interface/driver_info.h"
 #include "shared/source/os_interface/linux/cache_info.h"
 #include "shared/source/os_interface/linux/engine_info.h"
 #include "shared/source/os_interface/linux/hw_device_id.h"
@@ -127,6 +128,8 @@ class Drm {
     int setupHardwareInfo(DeviceDescriptor *, bool);
     void setupSystemInfo(HardwareInfo *hwInfo, SystemInfo &sysInfo);
     void setupCacheInfo(const HardwareInfo &hwInfo);
+
+    PhysicalDevicePciBusInfo getPciBusInfo() const;
 
     bool areNonPersistentContextsSupported() const { return nonPersistentContextsSupported; }
     void checkNonPersistentContextsSupport();

--- a/shared/source/os_interface/windows/driver_info_windows.h
+++ b/shared/source/os_interface/windows/driver_info_windows.h
@@ -19,7 +19,7 @@ class SettingsReader;
 
 class DriverInfoWindows : public DriverInfo {
   public:
-    DriverInfoWindows(std::string &&path);
+    DriverInfoWindows(const std::string &path, const PhysicalDevicePciBusInfo &pciBusInfo);
     ~DriverInfoWindows();
     std::string getDeviceName(std::string defaultName) override;
     std::string getVersion(std::string defaultVersion) override;

--- a/shared/source/os_interface/windows/wddm/wddm.h
+++ b/shared/source/os_interface/windows/wddm/wddm.h
@@ -10,6 +10,7 @@
 #include "shared/source/gmm_helper/gmm_lib.h"
 #include "shared/source/helpers/debug_helpers.h"
 #include "shared/source/memory_manager/gfx_partition.h"
+#include "shared/source/os_interface/driver_info.h"
 #include "shared/source/os_interface/os_context.h"
 #include "shared/source/os_interface/windows/hw_device_id.h"
 #include "shared/source/os_interface/windows/wddm/wddm_defs.h"
@@ -170,6 +171,8 @@ class Wddm {
     const RootDeviceEnvironment &getRootDeviceEnvironment() const { return rootDeviceEnvironment; }
 
     const uint32_t getTimestampFrequency() const { return timestampFrequency; }
+
+    PhysicalDevicePciBusInfo getPciBusInfo() const;
 
   protected:
     std::unique_ptr<HwDeviceId> hwDeviceId;

--- a/shared/test/common/mocks/mock_driver_info.h
+++ b/shared/test/common/mocks/mock_driver_info.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018-2021 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+#pragma once
+
+#include "shared/source/os_interface/driver_info.h"
+
+namespace NEO {
+
+class DriverInfoMock : public DriverInfo {
+  public:
+    DriverInfoMock(){};
+
+    std::string getDeviceName(std::string defaultName) override { return deviceName; };
+    std::string getVersion(std::string defaultVersion) override { return version; };
+
+    void setDeviceName(const std::string &name) { deviceName = name; }
+    void setVersion(const std::string &versionString) { version = versionString; }
+
+    void setPciBusInfo(const PhysicalDevicePciBusInfo &info) {
+        pciBusInfo.pciDomain = info.pciDomain;
+        pciBusInfo.pciBus = info.pciBus;
+        pciBusInfo.pciDevice = info.pciDevice;
+        pciBusInfo.pciFunction = info.pciFunction;
+    }
+
+  private:
+    std::string deviceName;
+    std::string version;
+};
+
+} // namespace NEO


### PR DESCRIPTION
Add the extension to obtain PCI bus information about an OpenCL device.
It will allow profiling tools like Intel VTune to attribute the profiling
data to the appropriate device. And this extension will especially useful
if two or more identical devices are installed in the system.

Signed-off-by: Egor Suldin <egor.suldin@intel.com>