### PR TITLE
zesDeviceGetProperties(): Don't crash miserably when Sysman wasn't initialized

### DIFF
--- a/level_zero/api/sysman/zes_sysman.cpp
+++ b/level_zero/api/sysman/zes_sysman.cpp
@@ -11,7 +11,11 @@ ZE_APIEXPORT ze_result_t ZE_APICALL
 zesDeviceGetProperties(
     zes_device_handle_t hDevice,
     zes_device_properties_t *pProperties) {
-    return L0::SysmanDevice::fromHandle(hDevice)->deviceGetProperties(pProperties);
+    SysmanDevice sd = L0::SysmanDevice::fromHandle(hDevice);
+    if (sd != nullptr)
+      return sd->deviceGetProperties(pProperties);
+    else
+      return ZE_RESULT_ERROR_UNINITIALIZED;
 }
 
 ZE_APIEXPORT ze_result_t ZE_APICALL


### PR DESCRIPTION
This is an untested patch (don't know how to compile oneAPI) to provide a short-term workaround for segfaults reported in oneapi-src/level-zero#36

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>