### PR TITLE
Improve CI Travis builds

### DIFF
--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-11
@@ -10,6 +10,6 @@ RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unaut
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=1 -DSUPPORT_GEN12LP=0 \
-    -DBUILD_WITH_L0=0 ../neo; \
+    -DBUILD_WITH_L0=0 -DDONT_CARE_OF_VIRTUALS=1 -DUSE_ULT_PCH=1 ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-12
@@ -10,6 +10,6 @@ RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unaut
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=1 \
-    -DBUILD_WITH_L0=0 ../neo; \
+    -DBUILD_WITH_L0=0 -DDONT_CARE_OF_VIRTUALS=1 -DUSE_ULT_PCH=1 ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-8
@@ -10,6 +10,6 @@ RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unaut
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=1 -DSUPPORT_GEN9=0 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
-    -DBUILD_WITH_L0=0 ../neo; \
+    -DBUILD_WITH_L0=0 -DDONT_CARE_OF_VIRTUALS=1 -DUSE_ULT_PCH=1 ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
+++ b/scripts/docker/Dockerfile-ubuntu-20.04-gcc-gen-9
@@ -10,6 +10,6 @@ RUN apt-get -y update ; apt-get --no-install-recommends install -y --allow-unaut
 RUN mkdir /root/build; cd /root/build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
     -DSUPPORT_GEN8=0 -DSUPPORT_GEN9=1 -DSUPPORT_GEN11=0 -DSUPPORT_GEN12LP=0 \
-    -DBUILD_WITH_L0=0 ../neo; \
+    -DBUILD_WITH_L0=0 -DDONT_CARE_OF_VIRTUALS=1 -DUSE_ULT_PCH=1 ../neo; \
     ninja -j `nproc`
 CMD ["/bin/bash"]

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -15,5 +15,6 @@ then
 fi
 
 git clone ../compute-runtime neo && \
+([[ -z "$DOCKER_USERNAME" ]] || docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD") && \
 docker build -f scripts/docker/${DOCKERFILE} -t ${IMAGE} . && \
 docker images


### PR DESCRIPTION
login to docker account to use separated limit for docker image pulls
enable PCH and use virtuals in GCC builds on Ubuntu 20.04

Signed-off-by: Mateusz Jablonski <mateusz.jablonski@intel.com>