### PR TITLE
Remove indirection from ocloc_lib and ocloc names

### DIFF
--- a/opencl/source/built_ins/kernels/CMakeLists.txt
+++ b/opencl/source/built_ins/kernels/CMakeLists.txt
@@ -61,22 +61,11 @@ if(NOT NEO_DISABLE_BUILTINS_COMPILATION)
     unset(BUILTIN_CPP)
     # set variable outside function
     set(BUILTIN_CPP built_ins/${NEO_ARCH}/${gen_type_lower}/${BASENAME}_${family_name_with_type}.cpp PARENT_SCOPE)
-    if(NOT DEFINED cloc_cmd_prefix)
-      if(WIN32)
-        set(cloc_cmd_prefix ocloc)
-      else()
-        if(DEFINED NEO__IGC_LIBRARY_PATH)
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        else()
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        endif()
-      endif()
-    endif()
 
     list(APPEND __cloc__options__ "-cl-kernel-arg-info")
     add_custom_command(
                        OUTPUT ${OUTPUT_FILES}
-                       COMMAND ${cloc_cmd_prefix} -q -file ${FILENAME} -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -out_dir ${OUTPUTDIR} -options "$<JOIN:${__cloc__options__}, >"
+                       COMMAND ocloc -q -file ${FILENAME} -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -out_dir ${OUTPUTDIR} -options "$<JOIN:${__cloc__options__}, >"
                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        DEPENDS ${builtin} ocloc copy_compiler_files
     )

--- a/opencl/source/scheduler/scheduler_binary.cmake
+++ b/opencl/source/scheduler/scheduler_binary.cmake
@@ -33,23 +33,12 @@ function(compile_kernel target gen_type platform_type kernel)
 
   set(SCHEDULER_CPP "${OUTPUTDIR}/${BASENAME}_${family_name_with_type}.cpp")
 
-  if(NOT DEFINED cloc_cmd_prefix)
-    if(WIN32)
-      set(cloc_cmd_prefix ocloc)
-    else()
-      if(DEFINED NEO__IGC_LIBRARY_PATH)
-        set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-      else()
-        set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-      endif()
-    endif()
-  endif()
   list(APPEND __cloc__options__ "-cl-kernel-arg-info")
   list(APPEND __cloc__options__ "-cl-std=CL2.0")
   list(APPEND __cloc__options__ "-cl-intel-disable-a64WA")
   add_custom_command(
                      OUTPUT ${OUTPUTPATH}
-                     COMMAND ${cloc_cmd_prefix} -q -file ${kernel} -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} -cl-intel-greater-than-4GB-buffer-required -${NEO_BITS} -out_dir ${OUTPUTDIR} -cpp_file -options "$<JOIN:${__cloc__options__}, >" -internal_options "-cl-intel-no-spill"
+                     COMMAND ocloc -q -file ${kernel} -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} -cl-intel-greater-than-4GB-buffer-required -${NEO_BITS} -out_dir ${OUTPUTDIR} -cpp_file -options "$<JOIN:${__cloc__options__}, >" -internal_options "-cl-intel-no-spill"
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                      DEPENDS ${kernel} ocloc copy_compiler_files
   )

--- a/opencl/test/unit_test/CMakeLists.txt
+++ b/opencl/test/unit_test/CMakeLists.txt
@@ -177,18 +177,6 @@ target_include_directories(igdrcl_tests BEFORE PRIVATE
                            ${NEO_SHARED_TEST_DIRECTORY}/common/helpers/includes${BRANCH_DIR_SUFFIX}
 )
 
-if(NOT DEFINED cloc_cmd_prefix)
-  if(WIN32)
-    set(cloc_cmd_prefix ocloc)
-  else()
-    if(DEFINED NEO__IGC_LIBRARY_PATH)
-      set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-    else()
-      set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-    endif()
-  endif()
-endif()
-
 function(neo_gen_kernels platform_name_with_type platform_name revision_id suffix)
   set(outputdir "${TargetDir}/${suffix}/${revision_id}/test_files/${NEO_ARCH}/")
 
@@ -208,7 +196,7 @@ function(neo_gen_kernels platform_name_with_type platform_name revision_id suffi
 
       add_custom_command(
                          OUTPUT ${output_files}
-                         COMMAND ${cloc_cmd_prefix} -q -file ${filename} -device ${platform_name} -${NEO_BITS} -revision_id ${revision_id} -out_dir ${outputdir}
+                         COMMAND ocloc -q -file ${filename} -device ${platform_name} -${NEO_BITS} -revision_id ${revision_id} -out_dir ${outputdir}
                          WORKING_DIRECTORY ${workdir}
                          DEPENDS ${filepath} ocloc
       )
@@ -254,7 +242,7 @@ function(neo_gen_kernels_with_options platform_name_with_type platform_name revi
 
         add_custom_command(
                            OUTPUT ${output_files}
-                           COMMAND ${cloc_cmd_prefix} -file ${filename} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -revision_id ${revision_id} -options ${arg} -options_name
+                           COMMAND ocloc -file ${filename} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -revision_id ${revision_id} -options ${arg} -options_name
                            WORKING_DIRECTORY ${workdir}
                            DEPENDS ${filearg} ocloc
         )
@@ -306,7 +294,7 @@ function(neo_gen_kernels_with_internal_options platform_name_with_type platform_
 
     add_custom_command(
                        OUTPUT ${output_files}
-                       COMMAND ${cloc_cmd_prefix} -file ${filename} -device ${platform_name} -revision_id ${revision_id} -${NEO_BITS} -out_dir ${outputdir} ${output_name} -internal_options ${ARGN}
+                       COMMAND ocloc -file ${filename} -device ${platform_name} -revision_id ${revision_id} -${NEO_BITS} -out_dir ${outputdir} ${output_name} -internal_options ${ARGN}
                        WORKING_DIRECTORY ${workdir}
                        DEPENDS ${filearg} ocloc
     )
@@ -352,7 +340,7 @@ function(neo_gen_kernel_with_kernel_debug_options platform_name_with_type platfo
     )
     add_custom_command(
                        OUTPUT ${output_files}
-                       COMMAND ${cloc_cmd_prefix} -q -file ${filename} -device ${platform_name} -revision_id ${revision_id} -${NEO_BITS} -out_dir ${outputdir} -output ${argwospaces} -internal_options ${TEST_KERNEL_kernel_debug_enable} -options "-g"
+                       COMMAND ocloc -q -file ${filename} -device ${platform_name} -revision_id ${revision_id} -${NEO_BITS} -out_dir ${outputdir} -output ${argwospaces} -internal_options ${TEST_KERNEL_kernel_debug_enable} -options "-g"
                        WORKING_DIRECTORY ${workdir}
                        DEPENDS ${filepath} ocloc
     )
@@ -388,7 +376,7 @@ function(neo_gen_kernel_from_ll platform_name_with_type platform_name suffix fil
 
          add_custom_command(
                      OUTPUT ${output_files}
-                     COMMAND ${cloc_cmd_prefix} -q -file ${filename} -output ${output_name} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -internal_options ${compile_options} -llvm_input
+                     COMMAND ocloc -q -file ${filename} -output ${output_name} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -internal_options ${compile_options} -llvm_input
                      WORKING_DIRECTORY ${workdir}
                      DEPENDS ${filepath} ocloc
   )

--- a/shared/offline_compiler/source/CMakeLists.txt
+++ b/shared/offline_compiler/source/CMakeLists.txt
@@ -4,9 +4,8 @@
 # SPDX-License-Identifier: MIT
 #
 
-project(${OCLOC_NAME}_lib)
+project(ocloc_lib)
 
-set(OCLOC_NAME "ocloc")
 set(OCLOC_FOLDER_NAME "offline_compiler")
 
 set(CLOC_LIB_SRCS_LIB
@@ -150,12 +149,12 @@ set(CLOC_LIB_SRCS
     ${CLOC_LIB_SRCS_LIB}
     ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
 )
-add_library(${OCLOC_NAME}_lib SHARED ${CLOC_LIB_SRCS})
+add_library(ocloc_lib SHARED ${CLOC_LIB_SRCS})
 
 add_subdirectories()
 
-create_project_source_tree(${OCLOC_NAME}_lib)
-set_target_properties(${OCLOC_NAME}_lib PROPERTIES FOLDER ${OCLOC_FOLDER_NAME})
+create_project_source_tree(ocloc_lib)
+set_target_properties(ocloc_lib PROPERTIES FOLDER ${OCLOC_FOLDER_NAME})
 
 set(CLOC_LIB_INCLUDES
     ${ENGINE_NODE_DIR}
@@ -166,20 +165,20 @@ set(CLOC_LIB_INCLUDES
     ${NEO__IGC_INCLUDE_DIR}
 )
 
-target_include_directories(${OCLOC_NAME}_lib BEFORE PRIVATE ${CLOC_LIB_INCLUDES})
-target_include_directories(${OCLOC_NAME}_lib BEFORE PRIVATE ${IGA_INCLUDE_DIR})
+target_include_directories(ocloc_lib BEFORE PRIVATE ${CLOC_LIB_INCLUDES})
+target_include_directories(ocloc_lib BEFORE PRIVATE ${IGA_INCLUDE_DIR})
 
-target_compile_definitions(${OCLOC_NAME}_lib PUBLIC ${CLOC_LIB_LIB_FLAGS_DEFINITIONS} ${SUPPORTED_GEN_FLAGS_DEFINITONS} DEFAULT_PLATFORM=${DEFAULT_SUPPORTED_PLATFORM}
+target_compile_definitions(ocloc_lib PUBLIC ${CLOC_LIB_LIB_FLAGS_DEFINITIONS} ${SUPPORTED_GEN_FLAGS_DEFINITONS} DEFAULT_PLATFORM=${DEFAULT_SUPPORTED_PLATFORM}
                            IGA_LIBRARY_NAME=${CMAKE_SHARED_LIBRARY_PREFIX}${IGA_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
-target_compile_definitions(${OCLOC_NAME}_lib PUBLIC ${NEO__IGC_COMPILE_DEFINITIONS})
+target_compile_definitions(ocloc_lib PUBLIC ${NEO__IGC_COMPILE_DEFINITIONS})
 
 if(MSVC)
-  target_link_libraries(${OCLOC_NAME}_lib dbghelp)
+  target_link_libraries(ocloc_lib dbghelp)
 endif()
 
 if(UNIX)
-  target_link_libraries(${OCLOC_NAME}_lib dl pthread)
+  target_link_libraries(ocloc_lib dl pthread)
 endif()
 
 set(CLOC_LIB_SRCS_LIB ${CLOC_LIB_SRCS_LIB} PARENT_SCOPE)
@@ -189,11 +188,11 @@ set(OCLOC_SRCS
     ${OCLOC_DIRECTORY}/source/main.cpp
 )
 
-add_executable(${OCLOC_NAME} ${OCLOC_SRCS})
-target_link_libraries(${OCLOC_NAME} ${OCLOC_NAME}_lib)
+add_executable(ocloc ${OCLOC_SRCS})
+target_link_libraries(ocloc ocloc_lib)
 
-create_project_source_tree(${OCLOC_NAME})
-set_target_properties(${OCLOC_NAME} PROPERTIES FOLDER ${OCLOC_FOLDER_NAME})
+create_project_source_tree(ocloc)
+set_target_properties(ocloc PROPERTIES FOLDER ${OCLOC_FOLDER_NAME})
 
 if(MSVC)
   if(CMAKE_SIZEOF_VOID_P EQUAL 4)
@@ -207,42 +206,42 @@ endif()
 
 if(UNIX)
   if(NEO_BUILD_DEBUG_SYMBOLS_PACKAGE)
-    get_filename_component(lib_file_name $<TARGET_FILE:${OCLOC_NAME}_lib> NAME_WE)
+    get_filename_component(lib_file_name $<TARGET_FILE:ocloc_lib> NAME_WE)
     set(symbols_file_name ${lib_file_name}.debug)
-    set(debug_symbols_target_name "${STRIP_SYMBOLS_TARGET}_${OCLOC_NAME}_lib")
+    set(debug_symbols_target_name "${STRIP_SYMBOLS_TARGET}_ocloc_lib")
     add_custom_target(${debug_symbols_target_name}
                       COMMAND sh -c "objcopy --only-keep-debug ${lib_file_name} ${symbols_file_name}"
                       COMMAND sh -c "strip -g ${lib_file_name}"
                       COMMAND sh -c "objcopy --add-gnu-debuglink=${symbols_file_name} ${lib_file_name}"
     )
-    add_dependencies(${debug_symbols_target_name} ${OCLOC_NAME}_lib)
+    add_dependencies(${debug_symbols_target_name} ocloc_lib)
     add_dependencies(${STRIP_SYMBOLS_TARGET} ${debug_symbols_target_name})
     set_property(GLOBAL APPEND PROPERTY DEBUG_SYMBOL_FILES "${symbols_file_name}")
   endif()
 
-  set_property(GLOBAL APPEND PROPERTY NEO_OCL_COMPONENTS_LIST ${OCLOC_NAME})
-  install(FILES $<TARGET_FILE:${OCLOC_NAME}>
+  set_property(GLOBAL APPEND PROPERTY NEO_OCL_COMPONENTS_LIST ocloc)
+  install(FILES $<TARGET_FILE:ocloc>
           DESTINATION ${CMAKE_INSTALL_BINDIR}
           PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-          COMPONENT ${OCLOC_NAME}
+          COMPONENT ocloc
   )
-  install(FILES $<TARGET_FILE:${OCLOC_NAME}_lib>
+  install(FILES $<TARGET_FILE:ocloc_lib>
           DESTINATION ${CMAKE_INSTALL_LIBDIR}
           PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-          COMPONENT ${OCLOC_NAME}
+          COMPONENT ocloc
   )
   install(FILES ${OCLOC_DIRECTORY}/source/ocloc_api.h
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-          COMPONENT ${OCLOC_NAME}
+          COMPONENT ocloc
   )
 elseif(WIN32)
   if(NEO_WINDOWS_INSTALL)
-    install(TARGETS ${OCLOC_NAME}
+    install(TARGETS ocloc
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT ocloc
     )
-    install(TARGETS ${OCLOC_NAME}_lib
+    install(TARGETS ocloc_lib
             DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT ocloc
     )
@@ -253,8 +252,8 @@ elseif(WIN32)
   endif()
 endif()
 
-set(OCLOC_OUTPUT_NAME "${OCLOC_NAME}${OCLOC_BITNESS_SUFFIX}")
-set_target_properties(${OCLOC_NAME}_lib PROPERTIES OUTPUT_NAME ${OCLOC_OUTPUT_NAME})
+set(OCLOC_OUTPUT_NAME "ocloc${OCLOC_BITNESS_SUFFIX}")
+set_target_properties(ocloc_lib PROPERTIES OUTPUT_NAME ${OCLOC_OUTPUT_NAME})
 
 add_custom_target(copy_compiler_files DEPENDS ${NEO__IGC_TARGETS})
 set_target_properties(copy_compiler_files PROPERTIES FOLDER ${OCLOC_FOLDER_NAME})
@@ -264,8 +263,8 @@ if(WIN32)
     add_custom_command(
                        TARGET copy_compiler_files
                        PRE_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${OCLOC_NAME}_lib>
-                       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${TARGET_tmp}> $<TARGET_FILE_DIR:${OCLOC_NAME}_lib>
+                       COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:ocloc_lib>
+                       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${TARGET_tmp}> $<TARGET_FILE_DIR:ocloc_lib>
     )
   endforeach()
 endif()

--- a/shared/source/built_ins/kernels/CMakeLists.txt
+++ b/shared/source/built_ins/kernels/CMakeLists.txt
@@ -64,22 +64,11 @@ if(NOT NEO_DISABLE_BUILTINS_COMPILATION)
         ${OUTPUTDIR}/${mode}_${BASENAME}_${family_name_with_type}.spv
     )
 
-    if(NOT DEFINED cloc_cmd_prefix)
-      if(WIN32)
-        set(cloc_cmd_prefix ocloc)
-      else()
-        if(DEFINED NEO__IGC_LIBRARY_PATH)
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        else()
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        endif()
-      endif()
-    endif()
     list(APPEND __cloc__options__ "-cl-kernel-arg-info")
     set(INTERNAL_OPTIONS "${${mode}_OPTIONS}")
     add_custom_command(
                        OUTPUT ${OUTPUT_FILE_SPV}
-                       COMMAND ${cloc_cmd_prefix} -q -file ${FILENAME} -spv_only -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -output ${mode}_${BASENAME} -out_dir ${OUTPUTDIR} ${INTERNAL_OPTIONS} -options "$<JOIN:${__cloc__options__}, >"
+                       COMMAND ocloc -q -file ${FILENAME} -spv_only -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -output ${mode}_${BASENAME} -out_dir ${OUTPUTDIR} ${INTERNAL_OPTIONS} -options "$<JOIN:${__cloc__options__}, >"
                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        DEPENDS ${builtin} ocloc copy_compiler_files
     )
@@ -95,7 +84,7 @@ if(NOT NEO_DISABLE_BUILTINS_COMPILATION)
       list(APPEND BUILTINS_COMMANDS "${OUTPUT_FILE_CPP}")
       add_custom_command(
                          OUTPUT ${OUTPUT_FILES_BINARIES}
-                         COMMAND ${cloc_cmd_prefix} -q -file ${OUTPUT_FILE_SPV} -spirv_input -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -output ${mode}_${BASENAME}_${REVISION_ID} -out_dir ${OUTPUTDIR} -revision_id ${REVISION_ID} ${INTERNAL_OPTIONS} -options "$<JOIN:${__cloc__options__}, >"
+                         COMMAND ocloc -q -file ${OUTPUT_FILE_SPV} -spirv_input -device ${DEFAULT_SUPPORTED_${gen_type}_${platform_type}_PLATFORM} ${builtin_options} -${bits} -output ${mode}_${BASENAME}_${REVISION_ID} -out_dir ${OUTPUTDIR} -revision_id ${REVISION_ID} ${INTERNAL_OPTIONS} -options "$<JOIN:${__cloc__options__}, >"
                          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                          DEPENDS ${OUTPUT_FILE_SPV} ocloc copy_compiler_files
       )
@@ -110,18 +99,6 @@ if(NOT NEO_DISABLE_BUILTINS_COMPILATION)
   endfunction()
 
   function(generate_cpp_spirv builtin)
-    if(NOT DEFINED cloc_cmd_prefix)
-      if(WIN32)
-        set(cloc_cmd_prefix $<TARGET_FILE:ocloc>)
-      else()
-        if(DEFINED NEO__IGC_LIBRARY_PATH)
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        else()
-          set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-        endif()
-      endif()
-    endif()
-
     get_filename_component(BASENAME ${builtin} NAME_WE)
     get_filename_component(DIR ${builtin} DIRECTORY)
 
@@ -139,7 +116,7 @@ if(NOT NEO_DISABLE_BUILTINS_COMPILATION)
     set(OUTPUT_LIST_CPP_FILES ${OUTPUT_LIST_CPP_FILES} ${OUTPUT_FILE_CPP} PARENT_SCOPE)
     add_custom_command(
                        OUTPUT ${GENERATED_SPV_INPUT}
-                       COMMAND ${cloc_cmd_prefix} -q -spv_only -file ${INPUT_FILENAME} -out_dir ${OUTPUTDIR} -output_no_suffix -options "-cl-kernel-arg-info"
+                       COMMAND ocloc -q -spv_only -file ${INPUT_FILENAME} -out_dir ${OUTPUTDIR} -output_no_suffix -options "-cl-kernel-arg-info"
                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                        DEPENDS ${INPUT_FILENAME} ocloc copy_compiler_files
     )

--- a/shared/test/common/test_files/CMakeLists.txt
+++ b/shared/test/common/test_files/CMakeLists.txt
@@ -5,17 +5,6 @@
 #
 
 set(SHARED_TEST_PROJECTS_SUB_FOLDER "prepare test files")
-if(NOT DEFINED cloc_cmd_prefix)
-  if(WIN32)
-    set(cloc_cmd_prefix ocloc)
-  else()
-    if(DEFINED NEO__IGC_LIBRARY_PATH)
-      set(cloc_cmd_prefix LD_LIBRARY_PATH=${NEO__IGC_LIBRARY_PATH}:$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-    else()
-      set(cloc_cmd_prefix LD_LIBRARY_PATH=$<TARGET_FILE_DIR:ocloc_lib> $<TARGET_FILE:ocloc>)
-    endif()
-  endif()
-endif()
 
 function(compile_kernels_gen platform_name_with_type revision_id platform_name suffix)
 
@@ -38,7 +27,7 @@ function(compile_kernels_gen platform_name_with_type revision_id platform_name s
 
       add_custom_command(
                          OUTPUT ${output_files}
-                         COMMAND ${cloc_cmd_prefix} -file ${filename} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -revision_id ${revision_id}
+                         COMMAND ocloc -file ${filename} -device ${platform_name} -${NEO_BITS} -out_dir ${outputdir} -revision_id ${revision_id}
                          WORKING_DIRECTORY ${workdir}
                          DEPENDS ${filepath} ocloc copy_compiler_files
       )


### PR DESCRIPTION
```
This allows CMAKE to wrap the executable with
-DCMAKE_CROSSCOMPILING_EMULATOR=...

Signed-off-by: Zoltán Böszörményi <zboszor@gmail.com>
```