### PR TITLE
'std::unique_ptr' is defined in header '<memory>'

### DIFF
--- a/shared/generate_cpp_array/source/generate_cpp_array.cpp
+++ b/shared/generate_cpp_array/source/generate_cpp_array.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Intel Corporation
+ * Copyright (C) 2020-2022 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 constexpr int MIN_ARG_COUNT = 7;


### PR DESCRIPTION
Fixes GCC 12 build as std::unique_ptr is now defined in memory header. There are still bunch of warnings during the compilation, but this change makes it possible to compile with GCC 12.