### PR TITLE
zeCommandListAppendMemoryFill fails to fill with 2 byte pattern

### DIFF
--- a/level_zero/core/source/cmdlist/cmdlist_hw.inl
+++ b/level_zero/core/source/cmdlist/cmdlist_hw.inl
@@ -1500,7 +1500,8 @@ ze_result_t CommandListCoreFamily<gfxCoreFamily>::appendMemoryFill(void *ptr,
         builtinFunction->setGroupSize(groupSizeX, groupSizeY, groupSizeZ);
 
         uint32_t groups = static_cast<uint32_t>(adjustedSize) / groupSizeX;
-        uint32_t groupRemainderSizeX = static_cast<uint32_t>(size) % groupSizeX;
+        uint32_t remainingBytes = static_cast<uint32_t>(adjustedSize % groupSizeX) * middleElSize +
+                                  size % middleElSize;
 
         size_t patternAllocationSize = alignUp(patternSize, MemoryConstants::cacheLineSize);
         uint32_t patternSizeInEls = static_cast<uint32_t>(patternAllocationSize / middleElSize);
@@ -1541,7 +1542,7 @@ ze_result_t CommandListCoreFamily<gfxCoreFamily>::appendMemoryFill(void *ptr,
             return res;
         }
 
-        if (groupRemainderSizeX) {
+        if (remainingBytes) {
             uint32_t dstOffsetRemainder = groups * groupSizeX * static_cast<uint32_t>(middleElSize);
             uint64_t patternOffsetRemainder = (groupSizeX * groups & (patternSizeInEls - 1)) * middleElSize;
 
@@ -1552,7 +1553,7 @@ ze_result_t CommandListCoreFamily<gfxCoreFamily>::appendMemoryFill(void *ptr,
                 builtinFunctionRemainder = device->getBuiltinFunctionsLib()->getFunction(Builtin::FillBufferRightLeftover);
             }
 
-            builtinFunctionRemainder->setGroupSize(groupRemainderSizeX, 1u, 1u);
+            builtinFunctionRemainder->setGroupSize(remainingBytes, 1u, 1u);
             ze_group_count_t dispatchFuncArgs{1u, 1u, 1u};
 
             builtinFunctionRemainder->setArgBufferWithAlloc(0,
@@ -1564,7 +1565,7 @@ ze_result_t CommandListCoreFamily<gfxCoreFamily>::appendMemoryFill(void *ptr,
             builtinFunctionRemainder->setArgBufferWithAlloc(2,
                                                             reinterpret_cast<uintptr_t>(patternGfxAllocPtr) + patternOffsetRemainder,
                                                             patternGfxAlloc);
-            builtinFunctionRemainder->setArgumentValue(3, sizeof(patternSizeInEls), &patternSizeInEls);
+            builtinFunctionRemainder->setArgumentValue(3, sizeof(patternAllocationSize), &patternAllocationSize);
             res = appendLaunchKernelSplit(builtinFunctionRemainder->toHandle(), &dispatchFuncArgs, hSignalEvent);
             if (res) {
                 return res;

--- a/level_zero/core/test/black_box_tests/zello_copy.cpp
+++ b/level_zero/core/test/black_box_tests/zello_copy.cpp
@@ -223,6 +223,59 @@ void testAppendMemoryCopy2DRegion(ze_context_handle_t context, ze_device_handle_
     SUCCESS_OR_TERMINATE(zeCommandQueueDestroy(cmdQueue));
 }
 
+void testMemoryFillWithWordSizedPattern(ze_context_handle_t context, ze_device_handle_t &device, bool &validRet) {
+    const size_t allocSize = 10;
+    char pattern[] = {'\001', '\002'};
+    void *zeBuffer = nullptr;
+
+    ze_command_queue_handle_t cmdQueue;
+    ze_command_list_handle_t cmdList;
+
+    cmdQueue = createCommandQueue(context, device, nullptr);
+    SUCCESS_OR_TERMINATE(createCommandList(context, device, cmdList));
+
+    // Initialize buffers
+    ze_device_mem_alloc_desc_t deviceDesc = {};
+    deviceDesc.stype = ZE_STRUCTURE_TYPE_DEVICE_MEM_ALLOC_DESC;
+    deviceDesc.pNext = nullptr;
+    deviceDesc.ordinal = 0;
+    deviceDesc.flags = 0;
+
+    ze_host_mem_alloc_desc_t hostDesc = {};
+    hostDesc.stype = ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC;
+    hostDesc.pNext = nullptr;
+    hostDesc.flags = 0;
+
+    SUCCESS_OR_TERMINATE(
+        zeMemAllocShared(context, &deviceDesc, &hostDesc,
+                         allocSize, 1, device, &zeBuffer));
+
+    SUCCESS_OR_TERMINATE(zeCommandListAppendMemoryFill(cmdList, zeBuffer, &pattern, sizeof(pattern), allocSize,
+                                                       nullptr, 0, nullptr));
+
+    SUCCESS_OR_TERMINATE(zeCommandListClose(cmdList));
+    SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(cmdQueue, 1, &cmdList, nullptr));
+    SUCCESS_OR_TERMINATE(zeCommandQueueSynchronize(cmdQueue, std::numeric_limits<uint32_t>::max()));
+
+    validRet = true;
+    char *zeBufferChar = reinterpret_cast<char *>(zeBuffer);
+    for (size_t i = 0; i < allocSize; ++i) {
+        if (zeBufferChar[i] != pattern[i % sizeof(pattern)]) {
+            validRet = false;
+            if (verbose) {
+                std::cout << "dstBufferChar[" << i << " ] "
+                          << static_cast<unsigned int>(zeBufferChar[i])
+                          << "!= pattern " << pattern[i % sizeof(pattern)] << "\n";
+            }
+            break;
+        }
+    }
+
+    SUCCESS_OR_TERMINATE(zeMemFree(context, zeBuffer));
+    SUCCESS_OR_TERMINATE(zeCommandListDestroy(cmdList));
+    SUCCESS_OR_TERMINATE(zeCommandQueueDestroy(cmdQueue));
+}
+
 void testAppendMemoryFillWithSomePattern(ze_context_handle_t context, ze_device_handle_t &device, bool &validRet) {
     const size_t allocSize = 4096 + 7;
 
@@ -464,6 +517,8 @@ int main(int argc, char *argv[]) {
         testAppendMemoryFillWithSomePattern(context, device, outputValidationSuccessful);
     if (outputValidationSuccessful)
         testAppendMemoryCopy3DRegion(context, device, outputValidationSuccessful);
+    if (outputValidationSuccessful)
+        testMemoryFillWithWordSizedPattern(context, device, outputValidationSuccessful);
 
     SUCCESS_OR_TERMINATE(zeContextDestroy(context));
     std::cout << "\nZello Copy Results validation " << (outputValidationSuccessful ? "PASSED" : "FAILED") << "\n";


### PR DESCRIPTION
Rebase of https://github.com/intel/compute-runtime/pull/457, ref https://github.com/JuliaGPU/oneAPI.jl/issues/108.