### PR TITLE
Fix metrics discovery library detection

### DIFF
--- a/cmake/find_metrics.cmake
+++ b/cmake/find_metrics.cmake
@@ -78,7 +78,7 @@ if(NOT NEO__METRICS_LIBRARY_INCLUDE_DIR STREQUAL "")
 endif()
 
 # Metrics Discovery Detection
-dependency_detect("Metrics Discovery" "" METRICS_DISCOVERY "../metrics/discovery" TRUE)
+dependency_detect("Metrics Discovery" libmd METRICS_DISCOVERY "../metrics/discovery" TRUE)
 if(NOT NEO__METRICS_DISCOVERY_INCLUDE_DIR STREQUAL "")
   include_directories("${NEO__METRICS_DISCOVERY_INCLUDE_DIR}")
 endif()


### PR DESCRIPTION
Add missing "libmd" to metrics discovery detection.