### PR TITLE
Slightly improve "ocloc ids" output

### DIFF
--- a/opencl/test/unit_test/offline_compiler/ocloc_api_tests.cpp
+++ b/opencl/test/unit_test/offline_compiler/ocloc_api_tests.cpp
@@ -176,7 +176,7 @@ TEST(OclocApiTests, GivenInvalidQueryWhenQueryingThenErrorIsReturned) {
     std::string output = testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(retVal, NEO::OclocErrorCode::INVALID_COMMAND_LINE);
-    EXPECT_STREQ("Error: Invalid command line. Uknown argument unknown_query.", output.c_str());
+    EXPECT_STREQ("Error: Invalid command line. Unknown argument unknown_query.", output.c_str());
 }
 
 TEST(OclocApiTests, givenNoAcronymWhenIdsCommandIsInvokeThenErrorIsReported) {
@@ -209,7 +209,7 @@ TEST(OclocApiTests, givenUnknownAcronymWhenIdsCommandIsInvokeThenErrorIsReported
     std::string output = testing::internal::GetCapturedStdout();
 
     EXPECT_EQ(retVal, NEO::OclocErrorCode::INVALID_COMMAND_LINE);
-    EXPECT_STREQ("Error: Invalid command line. Uknown acronym unk.\n", output.c_str());
+    EXPECT_STREQ("Error: Invalid command line. Unknown acronym unk.\n", output.c_str());
 }
 
 TEST(OclocApiTests, WhenGoodFamilyNameIsProvidedThenSuccessIsReturned) {

--- a/opencl/test/unit_test/offline_compiler/offline_compiler_tests.cpp
+++ b/opencl/test/unit_test/offline_compiler/offline_compiler_tests.cpp
@@ -752,10 +752,10 @@ TEST_F(OfflineCompilerTests, givenFamilyAcronymWhenIdsCommandIsInvokeThenSuccess
         testing::internal::CaptureStdout();
         int retVal = OfflineCompiler::queryAcronymIds(argv.size(), argv, oclocArgHelperWithoutInput.get());
         std::string output = testing::internal::GetCapturedStdout();
-        expectedOutput << "Matched ids:";
+        expectedOutput << "Matched ids:\n";
 
         for (const auto &prefix : expected) {
-            expectedOutput << "\n" + prefix;
+            expectedOutput << prefix << "\n";
         }
         EXPECT_STREQ(expectedOutput.str().c_str(), output.c_str());
         EXPECT_EQ(OclocErrorCode::SUCCESS, retVal);
@@ -786,10 +786,10 @@ TEST_F(OfflineCompilerTests, givenReleaseAcronymWhenIdsCommandIsInvokeThenSucces
         testing::internal::CaptureStdout();
         int retVal = OfflineCompiler::queryAcronymIds(argv.size(), argv, oclocArgHelperWithoutInput.get());
         std::string output = testing::internal::GetCapturedStdout();
-        expectedOutput << "Matched ids:";
+        expectedOutput << "Matched ids:\n";
 
         for (const auto &prefix : expected) {
-            expectedOutput << "\n" + prefix;
+            expectedOutput << prefix << "\n";
         }
         EXPECT_STREQ(expectedOutput.str().c_str(), output.c_str());
         EXPECT_EQ(OclocErrorCode::SUCCESS, retVal);
@@ -820,10 +820,10 @@ TEST_F(OfflineCompilerTests, givenProductAcronymWhenIdsCommandIsInvokeThenSucces
         testing::internal::CaptureStdout();
         int retVal = OfflineCompiler::queryAcronymIds(argv.size(), argv, oclocArgHelperWithoutInput.get());
         std::string output = testing::internal::GetCapturedStdout();
-        expectedOutput << "Matched ids:";
+        expectedOutput << "Matched ids:\n";
 
         for (const auto &prefix : expected) {
-            expectedOutput << "\n" + prefix;
+            expectedOutput << prefix << "\n";
         }
         EXPECT_STREQ(expectedOutput.str().c_str(), output.c_str());
         EXPECT_EQ(OclocErrorCode::SUCCESS, retVal);

--- a/shared/offline_compiler/source/offline_compiler.cpp
+++ b/shared/offline_compiler/source/offline_compiler.cpp
@@ -136,7 +136,7 @@ int OfflineCompiler::query(size_t numArgs, const std::vector<std::string> &allAr
     } else if ("--help" == arg) {
         printQueryHelp(helper);
     } else {
-        helper->printf("Error: Invalid command line. Uknown argument %s.", arg.c_str());
+        helper->printf("Error: Invalid command line. Unknown argument %s.", arg.c_str());
         retVal = INVALID_COMMAND_LINE;
     }
 
@@ -188,7 +188,7 @@ int OfflineCompiler::queryAcronymIds(size_t numArgs, const std::vector<std::stri
             }
         }
     } else {
-        helper->printf("Error: Invalid command line. Uknown acronym %s.\n", allArgs[2].c_str());
+        helper->printf("Error: Invalid command line. Unknown acronym %s.\n", allArgs[2].c_str());
         retVal = INVALID_COMMAND_LINE;
         return retVal;
     }
@@ -199,7 +199,7 @@ int OfflineCompiler::queryAcronymIds(size_t numArgs, const std::vector<std::stri
             os << "\n";
         os << prefix;
     }
-    helper->printf("Matched ids:\n%s", os.str().c_str());
+    helper->printf("Matched ids:\n%s\n", os.str().c_str());
 
     return retVal;
 }


### PR DESCRIPTION
- Add trailing newline, so the output looks nice in the terminal.
- "Uknown" -> "Unknown".

Signed-off-by: Andrey Alekseenko <al42and@gmail.com>