### PR TITLE
Include cstdint to fix GCC 13 build

### DIFF
--- a/shared/offline_compiler/source/ocloc_concat.h
+++ b/shared/offline_compiler/source/ocloc_concat.h
@@ -10,6 +10,7 @@
 #include "shared/source/utilities/arrayref.h"
 #include "shared/source/utilities/const_stringref.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/shared/source/ail/ail_configuration.h
+++ b/shared/source/ail/ail_configuration.h
@@ -9,6 +9,7 @@
 
 #include "igfxfmid.h"
 
+#include <cstdint>
 #include <string>
 
 /*

--- a/shared/source/compiler_interface/external_functions.h
+++ b/shared/source/compiler_interface/external_functions.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/shared/source/device_binary_format/ar/ar_encoder.h
+++ b/shared/source/device_binary_format/ar/ar_encoder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Intel Corporation
+ * Copyright (C) 2020-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -11,6 +11,7 @@
 #include "shared/source/utilities/arrayref.h"
 #include "shared/source/utilities/const_stringref.h"
 
+#include <cstdint>
 #include <vector>
 
 namespace NEO {

--- a/shared/source/os_interface/linux/drm_debug.h
+++ b/shared/source/os_interface/linux/drm_debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Intel Corporation
+ * Copyright (C) 2022-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/shared/source/os_interface/linux/drm_neo.h
+++ b/shared/source/os_interface/linux/drm_neo.h
@@ -18,6 +18,7 @@
 #include "igfxfmid.h"
 
 #include <array>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <mutex>

--- a/shared/source/os_interface/linux/pci_path.cpp
+++ b/shared/source/os_interface/linux/pci_path.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2021-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -9,6 +9,7 @@
 
 #include "shared/source/os_interface/linux/sys_calls.h"
 
+#include <cstdint>
 #include <string_view>
 #include <unistd.h>
 

--- a/shared/source/os_interface/linux/pmt_util.cpp
+++ b/shared/source/os_interface/linux/pmt_util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2021-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <fcntl.h>
 #include <map>
 #include <sstream>

--- a/shared/source/os_interface/linux/pmt_util.h
+++ b/shared/source/os_interface/linux/pmt_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Intel Corporation
+ * Copyright (C) 2021-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <poll.h>
 #include <string>

--- a/shared/source/os_interface/linux/print.cpp
+++ b/shared/source/os_interface/linux/print.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Intel Corporation
+ * Copyright (C) 2018-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -7,6 +7,7 @@
 
 #include "shared/source/os_interface/print.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 

--- a/shared/source/tbx/tbx_sockets.h
+++ b/shared/source/tbx/tbx_sockets.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2018-2021 Intel Corporation
+ * Copyright (C) 2018-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
 #pragma once
+#include <cstdint>
 #include <string>
 
 namespace NEO {

--- a/shared/source/tbx/tbx_sockets_imp.h
+++ b/shared/source/tbx/tbx_sockets_imp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Intel Corporation
+ * Copyright (C) 2018-2023 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -10,6 +10,7 @@
 
 #include "os_socket.h"
 
+#include <cstdint>
 #include <iostream>
 
 namespace NEO {


### PR DESCRIPTION
Fixes all the missing includes on the 22.53.25242.13 for Release buildconfig (there might be more in master/debug configs, didn't check that).