### PR TITLE
Include cstdint in elf.h to fix GCC 13 build

### DIFF
--- a/shared/source/device_binary_format/elf/elf.h
+++ b/shared/source/device_binary_format/elf/elf.h
@@ -9,6 +9,7 @@
 
 #include "shared/source/utilities/const_stringref.h"
 
+#include <cstdint>
 #include <stddef.h>
 
 namespace NEO {


### PR DESCRIPTION
Compilation regressed since 23.05 branch compared to earlier branches.