### PR TITLE
unified_memory_manager: mark comparison operators as const

### DIFF
--- a/shared/source/memory_manager/unified_memory_manager.h
+++ b/shared/source/memory_manager/unified_memory_manager.h
@@ -130,10 +130,10 @@ class SVMAllocsManager {
         size_t allocationSize;
         void *allocation;
         SvmCacheAllocationInfo(size_t allocationSize, void *allocation) : allocationSize(allocationSize), allocation(allocation) {}
-        bool operator<(SvmCacheAllocationInfo const &other) {
+        bool operator<(SvmCacheAllocationInfo const &other) const {
             return allocationSize < other.allocationSize;
         }
-        bool operator<(size_t const &size) {
+        bool operator<(size_t const &size) const {
             return allocationSize < size;
         }
     };


### PR DESCRIPTION
This fixes the build on some compilers, and is fairly obviously correct given the contents of the methods.