### PR TITLE
cl_execution_environment: don't redeclare an STL type

### DIFF
--- a/opencl/source/execution_environment/cl_execution_environment.h
+++ b/opencl/source/execution_environment/cl_execution_environment.h
@@ -8,12 +8,9 @@
 #pragma once
 #include "shared/source/execution_environment/execution_environment.h"
 
+#include <mutex>
 #include <utility>
 #include <vector>
-
-namespace std {
-struct once_flag;
-}
 
 namespace NEO {
 


### PR DESCRIPTION
Depending on the compiler and STL used, `std::once_flag` may actually be aliased into an internal namespace (e.g. `std::__1::once_flag`). Declaring it directly within `std` here may conflict with that if the actual `<mutex>` header is included in the same translation unit.

This regressed in 77b88f19a136a0b8817b04001f322bd4a03cee6c.