### PR TITLE
Fix wrong parameter passed to getModuleFileName

### DIFF
--- a/shared/source/os_interface/windows/driver_info_windows.cpp
+++ b/shared/source/os_interface/windows/driver_info_windows.cpp
@@ -23,7 +23,7 @@ std::string getCurrentLibraryPath() {
                                                  reinterpret_cast<LPCWSTR>(&getCurrentLibraryPath), &handle);
     if (status != 0) {
 
-        status = NEO::SysCalls::getModuleFileName(handle, pathW, sizeof(pathW));
+        status = NEO::SysCalls::getModuleFileName(handle, pathW, MAX_PATH);
         if (status != 0) {
             std::wcstombs(path, pathW, MAX_PATH);
             returnValue.append(path);


### PR DESCRIPTION
https://github.com/intel/compute-runtime/blob/662146ea17de31390394c380473784ed7f9811fd/shared/source/os_interface/windows/driver_info_windows.cpp#L26

MAX_PATH should be passed instead of sizeof(pathW) since it calls GetModuleFileNameW and
> [in] nSize
> 
> The size of the lpFilename buffer, in TCHARs.

https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew

Signed-off-by: Vladislav Ryabov <vladislav.ryabov@intel.com>
