### PR TITLE
Add parsing of OpenCL C++ -cl-std flags

### DIFF
--- a/opencl/source/program/program.cpp
+++ b/opencl/source/program/program.cpp
@@ -362,13 +362,21 @@ void Program::updateNonUniformFlag() {
     if (pos == std::string::npos) {
         programOptionVersion = 12u; // Default is 1.2
     } else {
-        std::stringstream ss{options.c_str() + pos + clStdOptionName.size()};
-        uint32_t majorV = 0u, minorV = 0u;
-        char dot = 0u;
-        ss >> majorV;
-        ss >> dot;
-        ss >> minorV;
-        programOptionVersion = majorV * 10u + minorV;
+        const std::string_view opt(options.c_str() + pos + clStdOptionName.size());
+
+        if (opt.find("CLC++") == 0 || opt.find("CLC++1.0") == 0) {
+            programOptionVersion = 20;
+        } else if (opt.find("CLC++2021") == 0) {
+            programOptionVersion = 30;
+        } else {
+            std::stringstream ss{options.c_str() + pos + clStdOptionName.size()};
+            uint32_t majorV = 0u, minorV = 0u;
+            char dot = 0u;
+            ss >> majorV;
+            ss >> dot;
+            ss >> minorV;
+            programOptionVersion = majorV * 10u + minorV;
+        }
     }
 
     if (programOptionVersion >= 20u && (false == CompilerOptions::contains(options, CompilerOptions::uniformWorkgroupSize))) {

--- a/shared/source/helpers/compiler_options_parser.cpp
+++ b/shared/source/helpers/compiler_options_parser.cpp
@@ -25,9 +25,19 @@ uint32_t getMajorVersion(const std::string &compileOptions) {
     if (clStdValuePosition == std::string::npos) {
         return 0;
     }
-    std::stringstream ss{compileOptions.c_str() + clStdValuePosition + clStdOptionName.size()};
+    
     uint32_t majorVersion;
-    ss >> majorVersion;
+    const std::string_view opt(compileOptions.c_str() + clStdValuePosition + clStdOptionName.size());
+
+    if (opt.find("CLC++") == 0 || opt.find("CLC++1.0") == 0) {
+        majorVersion = 2;
+    } else if (opt.find("CLC++2021") == 0) {
+        majorVersion = 3;
+    } else {
+        std::stringstream ss{compileOptions.c_str() + clStdValuePosition + clStdOptionName.size()};
+        ss >> majorVersion;
+    }
+
     return majorVersion;
 }
 


### PR DESCRIPTION
Hello!

Support for OpenCL C++ was added into LLVM 14, but IGC doesn't support parsing of those flags just yet. I've opened PRs which adds support for parsing these flags to the following repositories: [intel-graphics-compiler](https://github.com/intel/intel-graphics-compiler/pull/328), [compute-runtime](https://github.com/intel/compute-runtime/pull/731) and [opencl-clang](https://github.com/intel/opencl-clang/pull/510).

The options are passed down into LLVM which then happily compiles my C++ kernel.

PRs should be merged in the following order: opencl-clang, intel-graphics-compiler, then finally compute-runtime.

Kind regards,
-Lucas