### PR TITLE
fix: invalid pointer reference in gfx_core_helper_xehp_and_later

### DIFF
--- a/shared/source/helpers/gfx_core_helper_xehp_and_later.inl
+++ b/shared/source/helpers/gfx_core_helper_xehp_and_later.inl
@@ -78,7 +78,8 @@ const EngineInstancesContainer GfxCoreHelperHw<GfxFamily>::getGpgpuEngineInstanc
 
     EngineInstancesContainer engines;
 
-    if (hwInfo.featureTable.flags.ftrCCSNode && !rootDeviceEnvironment.getAILConfigurationHelper()->forceRcs()) {
+    auto ail = rootDeviceEnvironment.getAILConfigurationHelper();
+    if (hwInfo.featureTable.flags.ftrCCSNode && !((ail != nullptr) && ail->forceRcs())) {
         for (uint32_t i = 0; i < hwInfo.gtSystemInfo.CCSInfo.NumberOfCCSEnabled; i++) {
             engines.push_back({static_cast<aub_stream::EngineType>(i + aub_stream::ENGINE_CCS), EngineUsage::regular});
         }
@@ -86,7 +87,7 @@ const EngineInstancesContainer GfxCoreHelperHw<GfxFamily>::getGpgpuEngineInstanc
 
     if ((debugManager.flags.NodeOrdinal.get() == static_cast<int32_t>(aub_stream::EngineType::ENGINE_RCS)) ||
         hwInfo.featureTable.flags.ftrRcsNode ||
-        rootDeviceEnvironment.getAILConfigurationHelper()->forceRcs()) {
+        ((ail != nullptr) && ail->forceRcs())) {
         engines.push_back({aub_stream::ENGINE_RCS, EngineUsage::regular});
     }
 


### PR DESCRIPTION
Some plex users were experiencing a crash when tonemapping. I tracked it down to an invalid pointer reference when AIL is disabled.