### PR TITLE
performance: add low latency hint for exec queues

### DIFF
--- a/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
+++ b/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
@@ -1304,6 +1304,7 @@ int IoctlHelperXe::createDrmContext(Drm &drm, OsContextLinux &osContext, uint32_
     create.vm_id = drmVmId;
     create.instances = castToUint64(contextParamEngine.data());
     create.extensions = (extPropertyIndex > 0U ? castToUint64(extProperties.data()) : 0UL);
+    create.flags = DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT;
     applyContextFlags(&create, allocateInterrupt);
 
     int ret = IoctlHelper::ioctl(DrmIoctl::gemContextCreateExt, &create);

--- a/third_party/uapi-eudebug/drm/xe_drm.h
+++ b/third_party/uapi-eudebug/drm/xe_drm.h
@@ -1148,7 +1148,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(1 << 0)
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi-eudebug/drm/xe_drm.h
+++ b/third_party/uapi-eudebug/drm/xe_drm.h
@@ -1148,6 +1148,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi-eudebug/drm/xe_drm.h
+++ b/third_party/uapi-eudebug/drm/xe_drm.h
@@ -1148,7 +1148,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
+++ b/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
@@ -1121,7 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
+++ b/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
@@ -1121,6 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
+++ b/third_party/uapi/drm-uapi-helper/xe/xe_drm.h
@@ -1121,7 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(1 << 0)
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/upstream/xe/xe_drm.h
+++ b/third_party/uapi/upstream/xe/xe_drm.h
@@ -1121,7 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/upstream/xe/xe_drm.h
+++ b/third_party/uapi/upstream/xe/xe_drm.h
@@ -1121,6 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	1
 	/** @flags: MBZ */
 	__u32 flags;
 

--- a/third_party/uapi/upstream/xe/xe_drm.h
+++ b/third_party/uapi/upstream/xe/xe_drm.h
@@ -1121,7 +1121,7 @@ struct drm_xe_exec_queue_create {
 	/** @vm_id: VM to use for this exec queue */
 	__u32 vm_id;
 
-#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(0x1 << 1)
+#define DRM_XE_EXEC_QUEUE_LOW_LATENCY_HINT	(1 << 0)
 	/** @flags: MBZ */
 	__u32 flags;
 


### PR DESCRIPTION
When workloads submit compute kernels, it's required
to keep low submission latency.
Impact of submission overhead is significant in a burst model,
when application submits short-running kernels continuously.

Signed-off-by: Szymon Morek <szymon.morek@intel.com>