### PR TITLE
Block CPU VAs with 48th bit set on aarch64

### DIFF
--- a/shared/source/helpers/aligned_memory.h
+++ b/shared/source/helpers/aligned_memory.h
@@ -22,6 +22,9 @@
 
 template <typename T, typename TNoRef = typename std::remove_reference<T>::type>
 constexpr inline TNoRef alignUp(T before, size_t alignment) {
+    if (alignment == 0) {
+        return before;
+    }
     OPTIONAL_UNRECOVERABLE_IF(!Math::isPow2(alignment));
     TNoRef mask = static_cast<TNoRef>(alignment - 1);
     return (before + mask) & ~mask;

--- a/shared/source/memory_manager/gfx_partition.h
+++ b/shared/source/memory_manager/gfx_partition.h
@@ -133,6 +133,7 @@ class GfxPartition {
 
     OSMemory::ReservedCpuAddressRange &reservedCpuAddressRangeForHeapSvm;
     OSMemory::ReservedCpuAddressRange reservedCpuAddressRangeForHeapExtended{};
+    std::vector<OSMemory::ReservedCpuAddressRange> reservedCpuAddressRangesBlocked;
     std::unique_ptr<OSMemory> osMemory;
 };
 } // namespace NEO


### PR DESCRIPTION
aarch64 allows CPU VAs to be from `0x0000_0000_0000` to `0xFFFF_FFFF_FFFF` and additionally doesn't want the addresses to be canonized like they are in x86_64.
Since SVM relies on CPU and GPU addrs to line up, and mmap on aarch64 usually gives you an addr with the 48th bit set, this causes SVM to fail.
Reserving the addrs between `0x8000_0000_0000` and `0xFFFF_FFFF_FFFF` is a trick to ensure that future mmap calls give you addrs that line up with what one would get on a x86_64 system and makes the library work on aarch64 without any changes to canonization.