### PR TITLE
fix: In Linux CL/GL sharing, handle failed symbols lookup

### DIFF
--- a/opencl/source/sharings/gl/linux/gl_sharing_linux.h
+++ b/opencl/source/sharings/gl/linux/gl_sharing_linux.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -126,6 +126,10 @@ class GLSharingFunctionsLinux : public GLSharingFunctions {
     GLContext glHGLRCHandle = 0;
     GLContext glHGLRCHandleBkpCtx = 0;
     GLDisplay glHDCHandle = 0;
+
+    // Readiness
+    bool glXLoaded = false;
+    bool eglLoaded = false;
 
     // GL functions
     PFNglGetString glGetString = nullptr;

--- a/opencl/source/sharings/gl/linux/lin_enable_gl.cpp
+++ b/opencl/source/sharings/gl/linux/lin_enable_gl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -54,8 +54,15 @@ bool GlSharingContextBuilder::finalizeProperties(Context &context, int32_t &errc
         return true;
 
     if (contextData->glHGLRCHandle) {
-        context.registerSharing(new GLSharingFunctionsLinux(contextData->glHDCType, contextData->glHGLRCHandle,
-                                                            nullptr, contextData->glHDCHandle));
+        GLSharingFunctionsLinux *sharing_fn = new GLSharingFunctionsLinux(contextData->glHDCType,
+                                                                          contextData->glHGLRCHandle,
+                                                                          nullptr, contextData->glHDCHandle);
+        if (!sharing_fn->isOpenGlSharingSupported()) {
+            delete sharing_fn;
+            errcodeRet = CL_INVALID_PROPERTY;
+            return false;
+        }
+        context.registerSharing(sharing_fn);
     }
 
     contextData.reset(nullptr);


### PR DESCRIPTION
In some cases we endup with GL being found but neither GLX or EGL found and this currently leads to crash.

So to better handle this case (and others), we keep track if we found symbols or not.

If we're asked if CL/GL sharing is supported we check the load worked.

If it's during an actual context creation we check what we were given match what we could load and fail context property finalization if not.

If it's during an "info" request where we don't have any properties yet, we return yes if either GLX or EGL was found.