### PR TITLE
fix: Don't disable bindless allocation using an undocumented env var

### DIFF
--- a/shared/source/device/root_device.cpp
+++ b/shared/source/device/root_device.cpp
@@ -17,7 +17,6 @@
 #include "shared/source/helpers/gfx_core_helper.h"
 #include "shared/source/helpers/hw_info.h"
 #include "shared/source/memory_manager/memory_manager.h"
-#include "shared/source/os_interface/debug_env_reader.h"
 #include "shared/source/os_interface/os_context.h"
 #include "shared/source/utilities/software_tags_manager.h"
 
@@ -51,10 +50,7 @@ Device *RootDevice::getRootDevice() const {
 
 void RootDevice::createBindlessHeapsHelper() {
 
-    EnvironmentVariableReader envReader;
-    bool disableGlobalBindless = envReader.getSetting("NEO_L0_SYSMAN_NO_CONTEXT_MODE", false);
-
-    if (!disableGlobalBindless && ApiSpecificConfig::getGlobalBindlessHeapConfiguration(this->getReleaseHelper()) && ApiSpecificConfig::getBindlessMode(*this)) {
+    if (ApiSpecificConfig::getGlobalBindlessHeapConfiguration(this->getReleaseHelper()) && ApiSpecificConfig::getBindlessMode(*this)) {
         this->executionEnvironment->rootDeviceEnvironments[getRootDeviceIndex()]->createBindlessHeapsHelper(this, getNumGenericSubDevices() > 1);
     }
 }


### PR DESCRIPTION
Bindless allocation is a core functionality. Having obscure mechanisms disabling it at runtime leads to unwanted side effects, leading to application issues, for example on applications trying to use SYCL bindless textures, that are supposed to be available unconditionally on DG2 and newer (when texturing is supported).
This is what is assumed here:
https://github.com/oneapi-src/unified-runtime/blob/dd7d5c6256f7ec90be9753e6e5a24d06a6b36fd6/source/adapters/level_zero/device.cpp#L1095

This reverts commit 81644a46cc466a892270d1688f4da24c2165900c.