### PR TITLE
build: add missing headers for GCC 15

### DIFF
--- a/shared/generate_cpp_array/source/generate_cpp_array.cpp
+++ b/shared/generate_cpp_array/source/generate_cpp_array.cpp
@@ -1,10 +1,11 @@
 /*
- * Copyright (C) 2020-2024 Intel Corporation
+ * Copyright (C) 2020-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/shared/offline_compiler/source/decoder/iga_wrapper.h
+++ b/shared/offline_compiler/source/decoder/iga_wrapper.h
@@ -11,6 +11,7 @@
 
 #include "igfxfmid.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/shared/offline_compiler/source/ocloc_arg_helper.h
+++ b/shared/offline_compiler/source/ocloc_arg_helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Intel Corporation
+ * Copyright (C) 2020-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -11,6 +11,7 @@
 #include "shared/source/utilities/const_stringref.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <map>
 #include <memory>

--- a/shared/source/debugger/debugger.h
+++ b/shared/source/debugger/debugger.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2020-2023 Intel Corporation
+ * Copyright (C) 2020-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
 #pragma once
+#include <cstdint>
 #include <memory>
 namespace NEO {
 struct HardwareInfo;

--- a/shared/source/gmm_helper/gmm_helper.h
+++ b/shared/source/gmm_helper/gmm_helper.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <cstdint>
 #include <memory>
 
 namespace NEO {

--- a/shared/source/os_interface/device_factory.h
+++ b/shared/source/os_interface/device_factory.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2018-2023 Intel Corporation
+ * Copyright (C) 2018-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/shared/source/os_interface/os_memory.h
+++ b/shared/source/os_interface/os_memory.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2019-2022 Intel Corporation
+ * Copyright (C) 2019-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/shared/source/os_interface/os_time.h
+++ b/shared/source/os_interface/os_time.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2018-2024 Intel Corporation
+ * Copyright (C) 2018-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
  */
 
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <optional>
 

--- a/shared/source/program/program_info.h
+++ b/shared/source/program/program_info.h
@@ -10,6 +10,7 @@
 #include "shared/source/utilities/arrayref.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/shared/source/utilities/software_tags.h
+++ b/shared/source/utilities/software_tags.h
@@ -8,6 +8,7 @@
 #pragma once
 #include "shared/source/helpers/string.h"
 
+#include <cstdint>
 #include <string>
 
 namespace NEO {


### PR DESCRIPTION
For using [fixed width integer types](https://en.cppreference.com/w/cpp/types/integer), the [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint) C++ header needs to be explicitly included with GCC 15 due to [changes](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2) in libstdc++.

For details, see the [documentation](https://gcc.gnu.org/gcc-15/porting_to.html#cxx) about porting to GCC 15.
