### PR TITLE
Make access to sysfs lock-free

### DIFF
--- a/level_zero/sysman/source/shared/linux/sysman_fs_access_interface.cpp
+++ b/level_zero/sysman/source/shared/linux/sysman_fs_access_interface.cpp
@@ -61,7 +61,10 @@ FdCacheInterface::~FdCacheInterface() {
 
 template <typename T>
 ze_result_t FsAccessInterface::readValue(const std::string file, T &val) {
-    auto lock = this->obtainMutex();
+    std::unique_lock<std::mutex> lockObj;
+    if (needLock) {
+        lockObj = this->obtainMutex();
+    }
 
     std::string readVal(64, '\0');
     int fd = pFdCacheInterface->getFd(file);
@@ -84,7 +87,7 @@ ze_result_t FsAccessInterface::readValue(const std::string file, T &val) {
 }
 
 // Generic Filesystem Access
-FsAccessInterface::FsAccessInterface() {
+FsAccessInterface::FsAccessInterface(bool needLock) : needLock(needLock) {
     pFdCacheInterface = std::make_unique<FdCacheInterface>();
 }
 
@@ -398,7 +401,7 @@ void ProcFsAccessInterface::kill(const ::pid_t pid) {
 }
 
 // Sysfs Access
-SysFsAccessInterface::SysFsAccessInterface() = default;
+SysFsAccessInterface::SysFsAccessInterface() : FsAccessInterface(false) {}
 SysFsAccessInterface::~SysFsAccessInterface() = default;
 
 const std::string SysFsAccessInterface::drmPath = "/sys/class/drm/";

--- a/level_zero/sysman/source/shared/linux/sysman_fs_access_interface.h
+++ b/level_zero/sysman/source/shared/linux/sysman_fs_access_interface.h
@@ -64,8 +64,9 @@ class FsAccessInterface {
     virtual bool directoryExists(const std::string path);
 
   protected:
-    FsAccessInterface();
+    FsAccessInterface(bool needLock = true);
     MOCKABLE_VIRTUAL std::unique_lock<std::mutex> obtainMutex();
+    bool needLock;
 
   private:
     template <typename T>


### PR DESCRIPTION
This PR aims to remove the lock used in `SysFsAccessInterface`. The lock is not necessary and should be avoided based on below facts:

1. Simultaneous read/write operations against the same sysfs instance are atomic by design.
1. For simultaneous read/write operations to different sysfs instances belonging to the same device, it's the driver's responsibility to ensure the data consistency. If a lock is needed at user-level, this usually indicates defect at device driver.
1. According to the spec of Level Zero, most get/set function has the note `The implementation of this function should be lock-free.`.