### PR TITLE
test: add more missing headers for GCC 15

### DIFF
--- a/shared/test/common/test_macros/test_excludes.cpp
+++ b/shared/test/common/test_macros/test_excludes.cpp
@@ -9,6 +9,7 @@
 
 #include "shared/source/helpers/debug_helpers.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Needed for building with GCC 15 and later. Otherwise, a build error happens.

This seems to affect only the unit tests of the legacy version, as unit tests of the non-legacy version can be built fine without this change.

Same situation of commit: https://github.com/intel/compute-runtime/commit/e0362a7c39ba7a3ead3cbb74146cb961176a1734

See the mentioned commit message for the full explanation.