### PR TITLE
fix: Add another missing include for GCC 15

### DIFF
--- a/shared/source/os_interface/linux/local/dg1/drm_tip_helper.cpp
+++ b/shared/source/os_interface/linux/local/dg1/drm_tip_helper.cpp
@@ -7,6 +7,7 @@
 
 #include "shared/source/os_interface/linux/i915.h"
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
Same issue as: #871, #830