### PR TITLE
feature: brand string update for Arc B390/B370 on PTL

### DIFF
--- a/shared/source/dll/devices/devices_base.inl
+++ b/shared/source/dll/devices/devices_base.inl
@@ -13,10 +13,10 @@ DEVICE(0x674C, CriHwConfig)
 
 #if SUPPORT_XE3_CORE
 #ifdef SUPPORT_PTL
-DEVICE(0xB080, PtlHwConfig)
-DEVICE(0xB081, PtlHwConfig)
-DEVICE(0xB082, PtlHwConfig)
-DEVICE(0xB083, PtlHwConfig)
+NAMEDDEVICE(0xB080, PtlHwConfig, "Intel(R) Arc(TM) B390 GPU")
+NAMEDDEVICE(0xB081, PtlHwConfig, "Intel(R) Arc(TM) B370 GPU")
+NAMEDDEVICE(0xB082, PtlHwConfig, "Intel(R) Arc(TM) B390 GPU")
+NAMEDDEVICE(0xB083, PtlHwConfig, "Intel(R) Arc(TM) B370 GPU")
 DEVICE(0xB084, PtlHwConfig)
 DEVICE(0xB085, PtlHwConfig)
 DEVICE(0xB086, PtlHwConfig)


### PR DESCRIPTION
Updating device brand strings
Based on public support in Windows driver 32.0.101.8509 https://www.intel.com/content/www/us/en/download/785597/

Signed-off-by: nyanmisaka [nst799610810@gmail.com](mailto:nst799610810@gmail.com)

---

```
// iigd_dch.inf
INTEL_DEV_B080 = "Intel(R) Arc(TM)" "B390 GPU" 
INTEL_DEV_B081 = "Intel(R) Arc(TM)" "B370 GPU" 
INTEL_DEV_B082 = "Intel(R) Arc(TM)" "B390 GPU" 
INTEL_DEV_B083 = "Intel(R) Arc(TM)" "B370 GPU" 
```