### PR TITLE
feature:  add support for DRM_XE_VM_CREATE_NO_VM_OVERCOMMIT flag

### DIFF
--- a/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
+++ b/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
@@ -1174,6 +1174,9 @@ uint32_t IoctlHelperXe::getFlagsForVmCreate(bool disableScratch, bool enablePage
     bool debuggingEnabled = drm.getRootDeviceEnvironment().executionEnvironment.isDebuggingEnabled();
     if (enablePageFault || debuggingEnabled) {
         flags |= DRM_XE_VM_CREATE_FLAG_FAULT_MODE;
+        if (enablePageFault) {
+            flags |= DRM_XE_VM_CREATE_FLAG_NO_VM_OVERCOMMIT;
+        }
     }
     if (!disableScratch) {
         flags |= DRM_XE_VM_CREATE_FLAG_SCRATCH_PAGE;

--- a/third_party/uapi/drm-next/xe/xe_drm.h
+++ b/third_party/uapi/drm-next/xe/xe_drm.h
@@ -975,6 +975,12 @@ struct drm_xe_gem_mmap_offset {
  *    demand when accessed, and also allows per-VM overcommit of memory.
  *    The xe driver internally uses recoverable pagefaults to implement
  *    this.
+ *  - %DRM_XE_VM_CREATE_FLAG_NO_VM_OVERCOMMIT - Requires also
+ *    DRM_XE_VM_CREATE_FLAG_FAULT_MODE. This disallows per-VM overcommit
+ *    but only during a &DRM_IOCTL_XE_VM_BIND operation with the
+ *    %DRM_XE_VM_BIND_FLAG_IMMEDIATE flag set. This may be useful for
+ *    user-space naively probing the amount of available memory.
+
  */
 struct drm_xe_vm_create {
 	/** @extensions: Pointer to the first extension struct, if any */
@@ -983,6 +989,8 @@ struct drm_xe_vm_create {
 #define DRM_XE_VM_CREATE_FLAG_SCRATCH_PAGE	(1 << 0)
 #define DRM_XE_VM_CREATE_FLAG_LR_MODE	        (1 << 1)
 #define DRM_XE_VM_CREATE_FLAG_FAULT_MODE	(1 << 2)
+#define DRM_XE_VM_CREATE_FLAG_NO_VM_OVERCOMMIT  (1 << 3)
+
 	/** @flags: Flags */
 	__u32 flags;
 


### PR DESCRIPTION
Use DRM_XE_VM_CREATE_NO_VM_OVERCOMMIT when page faults are enabled