### PR TITLE
feature: support vmBind DECOMPRESS flag for resource handling

### DIFF
--- a/level_zero/core/source/context/context_imp.cpp
+++ b/level_zero/core/source/context/context_imp.cpp
@@ -1838,25 +1838,10 @@ bool ContextImp::isAllocationSuitableForCompression(const StructuresLookupTable 
     auto &hwInfo = device.getHwInfo();
     auto &gfxCoreHelper = device.getGfxCoreHelper();
     auto neoDevice = device.getNEODevice();
-    auto rootDeviceIndex = neoDevice->getRootDeviceIndex();
     auto &l0GfxCoreHelper = neoDevice->getRootDeviceEnvironment().getHelper<L0GfxCoreHelper>();
-    auto peerAccess = neoDevice->hasAnyPeerAccess();
 
     if (!l0GfxCoreHelper.usmCompressionSupported(hwInfo) || !gfxCoreHelper.isBufferSizeSuitableForCompression(allocSize) || structuresLookupTable.uncompressedHint) {
         return false;
-    }
-
-    if (peerAccess.value_or(false)) {
-        for (auto &dev : this->driverHandle->devices) {
-            if (rootDeviceIndex == dev->getRootDeviceIndex() || !l0GfxCoreHelper.usmCompressionSupported(dev->getHwInfo())) {
-                continue;
-            }
-            ze_bool_t canAccess = false;
-            ze_result_t checkResult = device.canAccessPeer(dev, &canAccess);
-            if (checkResult == ZE_RESULT_SUCCESS && canAccess) {
-                return false;
-            }
-        }
     }
 
     if (l0GfxCoreHelper.forceDefaultUsmCompressionSupport()) {

--- a/level_zero/core/source/driver/driver_handle.cpp
+++ b/level_zero/core/source/driver/driver_handle.cpp
@@ -909,6 +909,8 @@ NEO::GraphicsAllocation *DriverHandle::getPeerAllocation(Device *device,
         if (numHandles > 1) {
             peerAllocRootDeviceIndex = device->getNEODevice()->getRootDevice()->getRootDeviceIndex();
         }
+        auto &l0GfxCoreHelper = device->getNEODevice()->getRootDeviceEnvironment().getHelper<L0GfxCoreHelper>();
+        l0GfxCoreHelper.p2pDecompressBufferIfRequired(alloc, device->getDriverHandle());
         NEO::SvmAllocationData allocDataInternal(peerAllocRootDeviceIndex);
 
         if (numHandles > 1) {

--- a/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper.cpp
+++ b/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Intel Corporation
+ * Copyright (C) 2020-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -133,6 +133,9 @@ ze_record_replay_graph_exp_flags_t L0GfxCoreHelper::getRecordReplayGraphCapabili
     }
     auto &l0GfxCoreHelper = rootDeviceEnvironment.getHelper<L0GfxCoreHelper>();
     return l0GfxCoreHelper.getPlatformRecordReplayGraphCapabilities();
+}
+
+void L0GfxCoreHelper::p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, DriverHandle *driverHandle) const {
 }
 
 } // namespace L0

--- a/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper.h
+++ b/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper.h
@@ -11,6 +11,7 @@
 #include "shared/source/helpers/device_bitfield.h"
 #include "shared/source/helpers/heap_base_address_model.h"
 
+#include "level_zero/core/source/driver/driver_handle.h"
 #include "level_zero/driver_experimental/zex_graph.h"
 #include "level_zero/tools/source/debug/eu_thread.h"
 #include "level_zero/zet_intel_gpu_debug.h"
@@ -46,6 +47,7 @@ enum class RTASDeviceFormatInternal {
 struct CopyOffloadMode;
 struct Event;
 struct Device;
+struct DriverHandleImp;
 struct EventPool;
 struct EventDescriptor;
 
@@ -123,6 +125,7 @@ class L0GfxCoreHelper : public NEO::ApiGfxCoreHelper {
     virtual size_t getMaxFillPatternSizeForCopyEngine() const = 0;
     virtual uint64_t getSupportedCustomOperations1() const = 0;
     virtual uint64_t getSupportedCustomOperations2() const = 0;
+    virtual void p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, L0::DriverHandle *driverHandle) const = 0;
 
   protected:
     L0GfxCoreHelper() = default;
@@ -186,6 +189,7 @@ class L0GfxCoreHelperHw : public L0GfxCoreHelper {
     size_t getMaxFillPatternSizeForCopyEngine() const override;
     uint64_t getSupportedCustomOperations1() const override;
     uint64_t getSupportedCustomOperations2() const override;
+    void p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, L0::DriverHandle *driverHandle) const override;
 
   protected:
     L0GfxCoreHelperHw() = default;

--- a/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper_tgllp_to_pvc.inl
+++ b/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper_tgllp_to_pvc.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Intel Corporation
+ * Copyright (C) 2023-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -47,6 +47,10 @@ uint64_t L0GfxCoreHelperHw<Family>::getOaTimestampValidBits() const {
 template <typename Family>
 ze_record_replay_graph_exp_flags_t L0GfxCoreHelperHw<Family>::getPlatformRecordReplayGraphCapabilities() const {
     return 0u;
+}
+
+template <typename Family>
+void L0GfxCoreHelperHw<Family>::p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, DriverHandle *driverHandle) const {
 }
 
 } // namespace L0

--- a/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper_xe3_and_later.inl
+++ b/level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper_xe3_and_later.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Intel Corporation
+ * Copyright (C) 2025-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -89,4 +89,9 @@ template <typename Family>
 zet_debug_regset_type_intel_gpu_t L0GfxCoreHelperHw<Family>::getRegsetTypeForLargeGrfDetection() const {
     return ZET_DEBUG_REGSET_TYPE_SR_INTEL_GPU;
 }
+
+template <typename Family>
+void L0GfxCoreHelperHw<Family>::p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, DriverHandle *driverHandle) const {
+}
+
 } // namespace L0

--- a/level_zero/core/source/xe2_hpg_core/l0_gfx_core_helper_xe2_hpg_core.cpp
+++ b/level_zero/core/source/xe2_hpg_core/l0_gfx_core_helper_xe2_hpg_core.cpp
@@ -5,6 +5,10 @@
  *
  */
 
+#include "shared/source/command_stream/command_stream_receiver.h"
+#include "shared/source/gmm_helper/gmm.h"
+#include "shared/source/helpers/blit_properties.h"
+#include "shared/source/memory_manager/memory_operations_handler.h"
 #include "shared/source/xe2_hpg_core/hw_cmds.h"
 
 #include "level_zero/core/source/gfx_core_helpers/l0_gfx_core_helper_base.inl"
@@ -39,6 +43,25 @@ uint32_t L0GfxCoreHelperHw<Family>::getGrfRegisterCount(uint32_t *regPtr) const 
 template <>
 bool L0GfxCoreHelperHw<Family>::alwaysAllocateEventInLocalMem() const {
     return true;
+}
+
+template <>
+void L0GfxCoreHelperHw<Family>::p2pDecompressBufferIfRequired(NEO::GraphicsAllocation *alloc, DriverHandle *driverHandle) const {
+    if (not alloc->isCompressionEnabled()) {
+        return;
+    }
+
+    auto rootDeviceIndex = alloc->getRootDeviceIndex();
+    auto neoDevice = driverHandle->devices[rootDeviceIndex]->getNEODevice();
+    auto &rootDeviceEnvironment = neoDevice->getRootDeviceEnvironment();
+
+    NEO::MemoryOperationsHandler *memoryOperationsIface = rootDeviceEnvironment.memoryOperationsInterface.get();
+    if (memoryOperationsIface) {
+        auto status = memoryOperationsIface->decompress(neoDevice, *alloc);
+        if (status == NEO::MemoryOperationsStatus::success) {
+            alloc->getDefaultGmm()->applyAuxFlagsForBuffer(false);
+        }
+    }
 }
 
 #include "level_zero/core/source/helpers/l0_gfx_core_helper_factory_init.inl"

--- a/shared/source/execution_environment/execution_environment.h
+++ b/shared/source/execution_environment/execution_environment.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 Intel Corporation
+ * Copyright (C) 2018-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -67,6 +67,8 @@ class ExecutionEnvironment : public ReferenceTrackedObject<ExecutionEnvironment>
         devicePermissionError = value;
     }
     bool isDevicePermissionError() const { return devicePermissionError; }
+    bool isResourceDecompressionEnabled() const { return resourceDecompressionEnabled; };
+    void setResourceDecompressionEnabled(bool value) { resourceDecompressionEnabled = value; };
 
     void setOneApiPvcWaEnv(bool val) {
         oneApiPvcWaEnv = val;
@@ -104,6 +106,7 @@ class ExecutionEnvironment : public ReferenceTrackedObject<ExecutionEnvironment>
     bool fp64EmulationEnabled = false;
     bool oneApiPvcWaEnv = true;
     bool devicePermissionError = false;
+    bool resourceDecompressionEnabled = false;
 
     DeviceHierarchyMode deviceHierarchyMode = DeviceHierarchyMode::composite;
     DebuggingMode debuggingEnabledMode = DebuggingMode::disabled;

--- a/shared/source/gmm_helper/gmm.cpp
+++ b/shared/source/gmm_helper/gmm.cpp
@@ -199,6 +199,11 @@ void Gmm::applyAuxFlagsForBuffer(bool preferCompression) {
         resourceParams->Flags.Gpu.CCS = 1;
         resourceParams->Flags.Gpu.UnifiedAuxSurface = 1;
         compressionEnabled = true;
+    } else {
+        gfxCoreHelper.applyRenderCompressionFlag(*this, 0);
+        resourceParams->Flags.Gpu.CCS = 0;
+        resourceParams->Flags.Gpu.UnifiedAuxSurface = 0;
+        compressionEnabled = false;
     }
 
     PRINT_STRING(debugManager.flags.PrintGmmCompressionParams.get(), stdout,

--- a/shared/source/memory_manager/memory_operations_handler.h
+++ b/shared/source/memory_manager/memory_operations_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Intel Corporation
+ * Copyright (C) 2019-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,6 +21,7 @@ class MemoryOperationsHandler {
     virtual ~MemoryOperationsHandler() = default;
 
     virtual MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) = 0;
+    virtual MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) = 0;
     virtual MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) = 0;
     virtual MemoryOperationsStatus evict(Device *device, GraphicsAllocation &gfxAllocation) = 0;
     virtual MemoryOperationsStatus isResident(Device *device, GraphicsAllocation &gfxAllocation) = 0;

--- a/shared/source/memory_manager/unified_memory_manager.cpp
+++ b/shared/source/memory_manager/unified_memory_manager.cpp
@@ -508,11 +508,11 @@ void *SVMAllocsManager::createUnifiedMemoryAllocation(size_t size,
     bool compressionEnabled = false;
     AllocationType allocationType = getGraphicsAllocationTypeAndCompressionPreference(memoryProperties, compressionEnabled);
 
+    bool preferCompressed = true;
     if (compressionEnabled && memoryProperties.device) {
-        auto *releaseHelper = memoryProperties.device->getReleaseHelper();
-        if (releaseHelper && !releaseHelper->isUsmCompressionSupportedOnPeerAccess() &&
+        if (not memoryProperties.device->getExecutionEnvironment()->isResourceDecompressionEnabled() &&
             memoryProperties.device->hasAnyPeerAccess().value_or(false)) {
-            compressionEnabled = false;
+            preferCompressed = false;
         }
     }
 
@@ -533,6 +533,7 @@ void *SVMAllocsManager::createUnifiedMemoryAllocation(size_t size,
     unifiedMemoryProperties.flags.uncacheable = memoryProperties.allocationFlags.flags.locallyUncachedResource;
     unifiedMemoryProperties.flags.preferCompressed = compressionEnabled || memoryProperties.allocationFlags.flags.compressedHint;
     unifiedMemoryProperties.flags.preferCompressed &= memoryManager->isCompressionSupportedForShareable(memoryProperties.allocationFlags.flags.shareable);
+    unifiedMemoryProperties.flags.preferCompressed &= preferCompressed;
     unifiedMemoryProperties.flags.resource48Bit = memoryProperties.allocationFlags.flags.resource48Bit;
 
     if (memoryProperties.memoryType == InternalMemoryType::deviceUnifiedMemory) {

--- a/shared/source/os_interface/aub_memory_operations_handler.cpp
+++ b/shared/source/os_interface/aub_memory_operations_handler.cpp
@@ -93,6 +93,10 @@ MemoryOperationsStatus AubMemoryOperationsHandler::makeResidentWithinDevice(Arra
     return MemoryOperationsStatus::success;
 }
 
+MemoryOperationsStatus AubMemoryOperationsHandler::decompress(Device *device, GraphicsAllocation &gfxAllocation) {
+    return MemoryOperationsStatus::unsupported;
+}
+
 MemoryOperationsStatus AubMemoryOperationsHandler::lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) {
     return makeResident(device, gfxAllocations, false, false);
 }

--- a/shared/source/os_interface/aub_memory_operations_handler.h
+++ b/shared/source/os_interface/aub_memory_operations_handler.h
@@ -24,6 +24,7 @@ class AubMemoryOperationsHandler : public MemoryOperationsHandler {
     ~AubMemoryOperationsHandler() override = default;
 
     MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) override;
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override;
     MemoryOperationsStatus evict(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus isResident(Device *device, GraphicsAllocation &gfxAllocation) override;

--- a/shared/source/os_interface/linux/drm_buffer_object.cpp
+++ b/shared/source/os_interface/linux/drm_buffer_object.cpp
@@ -266,7 +266,7 @@ void BufferObject::printBOBindingResult(OsContext *osContext, uint32_t vmHandleI
 int BufferObject::bind(OsContext *osContext, uint32_t vmHandleId, const bool forcePagingFence) {
     int retVal = 0;
     auto contextId = getOsContextId(osContext);
-    if (!this->bindInfo[contextId][vmHandleId]) {
+    if (!this->bindInfo[contextId][vmHandleId] || this->isResourceDecompressRequired()) {
         retVal = this->drm->bindBufferObject(osContext, vmHandleId, this, forcePagingFence);
         if (debugManager.flags.PrintBOBindingResult.get()) {
             printBOBindingResult(osContext, vmHandleId, true, retVal);

--- a/shared/source/os_interface/linux/drm_buffer_object.h
+++ b/shared/source/os_interface/linux/drm_buffer_object.h
@@ -176,6 +176,9 @@ class BufferObject {
     bool isReadOnlyGpuResource() {
         return readOnlyGpuResource;
     }
+    bool isResourceDecompressRequired() {
+        return requiresResourceDecompress;
+    }
 
     void setAsReadOnly(bool isReadOnly) {
         readOnlyGpuResource = isReadOnly;
@@ -183,6 +186,9 @@ class BufferObject {
 
     void requireImmediateBinding(bool required) {
         requiresImmediateBinding = required;
+    }
+    void requireResourceDecompress(bool required) {
+        requiresResourceDecompress = required;
     }
 
     bool isExplicitResidencyRequired() {
@@ -308,6 +314,7 @@ class BufferObject {
     bool boHandleShared = false;
     bool allowCapture = false;
     bool requiresImmediateBinding = false;
+    bool requiresResourceDecompress = false;
     bool requiresExplicitResidency = false;
     bool requiresLocked = false;
     bool chunked = false;

--- a/shared/source/os_interface/linux/drm_memory_operations_handler_bind.cpp
+++ b/shared/source/os_interface/linux/drm_memory_operations_handler_bind.cpp
@@ -39,6 +39,51 @@ MemoryOperationsStatus DrmMemoryOperationsHandlerBind::makeResident(Device *devi
     return result;
 }
 
+MemoryOperationsStatus DrmMemoryOperationsHandlerBind::decompress(Device *device, GraphicsAllocation &gfxAllocation) {
+    auto drmAllocation = static_cast<DrmAllocation *>(&gfxAllocation);
+    auto &engines = device->getAllEngines();
+
+    std::lock_guard<std::mutex> lock(mutex);
+
+    auto setDecompressOnBOs = [&](bool value) {
+        if (drmAllocation->storageInfo.isChunked) {
+            if (auto bo = drmAllocation->getBO()) {
+                bo->requireResourceDecompress(value);
+            }
+        } else {
+            for (auto &bo : drmAllocation->getBOs()) {
+                if (bo) {
+                    bo->requireResourceDecompress(value);
+                }
+            }
+        }
+    };
+
+    for (const auto &engine : engines) {
+        auto osContext = engine.osContext;
+        auto deviceBitfield = osContext->getDeviceBitfield();
+
+        uint32_t devicesDone = 0u;
+        for (uint32_t vmHandleId = 0u; devicesDone < deviceBitfield.count(); vmHandleId++) {
+            if (not deviceBitfield.test(vmHandleId)) {
+                continue;
+            }
+            devicesDone++;
+
+            setDecompressOnBOs(true);
+
+            int retVal = drmAllocation->bindBOs(osContext, vmHandleId, nullptr, true, false);
+
+            setDecompressOnBOs(false);
+
+            if (retVal) {
+                return MemoryOperationsStatus::failed;
+            }
+        }
+    }
+    return MemoryOperationsStatus::success;
+}
+
 MemoryOperationsStatus DrmMemoryOperationsHandlerBind::lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) {
     for (auto gfxAllocation = gfxAllocations.begin(); gfxAllocation != gfxAllocations.end(); gfxAllocation++) {
         (*gfxAllocation)->setLockedMemory(true);

--- a/shared/source/os_interface/linux/drm_memory_operations_handler_bind.h
+++ b/shared/source/os_interface/linux/drm_memory_operations_handler_bind.h
@@ -18,6 +18,7 @@ class DrmMemoryOperationsHandlerBind : public DrmMemoryOperationsHandler {
 
     MemoryOperationsStatus makeResidentWithinOsContext(OsContext *osContext, ArrayRef<GraphicsAllocation *> gfxAllocations, bool evictable, const bool forcePagingFence, const bool acquireLock) override;
     MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) override;
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override;
     MemoryOperationsStatus evict(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus evictWithinOsContext(OsContext *osContext, GraphicsAllocation &gfxAllocation) override;

--- a/shared/source/os_interface/linux/drm_memory_operations_handler_default.cpp
+++ b/shared/source/os_interface/linux/drm_memory_operations_handler_default.cpp
@@ -50,6 +50,10 @@ MemoryOperationsStatus DrmMemoryOperationsHandlerDefault::makeResident(Device *d
     return ret;
 }
 
+MemoryOperationsStatus DrmMemoryOperationsHandlerDefault::decompress(Device *device, GraphicsAllocation &gfxAllocation) {
+    return MemoryOperationsStatus::unsupported;
+}
+
 MemoryOperationsStatus DrmMemoryOperationsHandlerDefault::lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) {
     OsContext *osContext = nullptr;
     for (auto gfxAllocation = gfxAllocations.begin(); gfxAllocation != gfxAllocations.end(); gfxAllocation++) {

--- a/shared/source/os_interface/linux/drm_memory_operations_handler_default.h
+++ b/shared/source/os_interface/linux/drm_memory_operations_handler_default.h
@@ -20,6 +20,7 @@ class DrmMemoryOperationsHandlerDefault : public DrmMemoryOperationsHandler {
 
     MemoryOperationsStatus makeResidentWithinOsContext(OsContext *osContext, ArrayRef<GraphicsAllocation *> gfxAllocations, bool evictable, const bool forcePagingFence, const bool acquireLock) override;
     MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) override;
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override;
     MemoryOperationsStatus isResident(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus evictWithinOsContext(OsContext *osContext, GraphicsAllocation &gfxAllocation) override;

--- a/shared/source/os_interface/linux/drm_neo.cpp
+++ b/shared/source/os_interface/linux/drm_neo.cpp
@@ -15,6 +15,7 @@
 #include "shared/source/gmm_helper/cache_settings_helper.h"
 #include "shared/source/gmm_helper/client_context/gmm_client_context.h"
 #include "shared/source/gmm_helper/gmm.h"
+#include "shared/source/gmm_helper/gmm_helper.h"
 #include "shared/source/gmm_helper/resource_info.h"
 #include "shared/source/helpers/basic_math.h"
 #include "shared/source/helpers/constants.h"
@@ -1624,13 +1625,14 @@ int changeBufferObjectBinding(Drm *drm, OsContext *osContext, uint32_t vmHandleI
         bool bindImmediate = bo->isImmediateBindingRequired();
         bool bindMakeResident = false;
         bool readOnlyResource = bo->isReadOnlyGpuResource();
+        bool decompressResource = bo->isResourceDecompressRequired();
 
         if (drm->useVMBindImmediate() || guaranteePagingFence) {
             bindMakeResident = bo->isExplicitResidencyRequired();
             bindImmediate = true;
         }
         bool bindLock = bo->isExplicitLockedMemoryRequired();
-        flags |= ioctlHelper->getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource);
+        flags |= ioctlHelper->getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource, decompressResource);
     }
 
     auto &bindAddresses = bo->getColourAddresses();
@@ -1669,7 +1671,15 @@ int changeBufferObjectBinding(Drm *drm, OsContext *osContext, uint32_t vmHandleI
             } else {
                 vmBind.extensions = castToUint64(extensions.get());
             }
-            vmBind.patIndex = bo->peekPatIndex();
+
+            if (bo->isResourceDecompressRequired()) {
+                GMM_RESOURCE_USAGE_TYPE usageType = GMM_RESOURCE_USAGE_OCL_BUFFER;
+                bool compressed = false;
+                bool cacheable = false;
+                vmBind.patIndex = static_cast<uint16_t>(drm->getRootDeviceEnvironment().getGmmClientContext()->cachePolicyGetPATIndex(nullptr, usageType, compressed, cacheable));
+            } else {
+                vmBind.patIndex = bo->peekPatIndex();
+            }
         } else {
             vmBind.extensions = castToUint64(extensions.get());
         }
@@ -1821,10 +1831,12 @@ int Drm::createDrmVirtualMemory(uint32_t &drmVmId) {
 
     if (ret == 0) {
         drmVmId = ctl.vmId;
+
         if (isSharedSystemAllocEnabled()) {
             auto &productHelper = rootDeviceEnvironment.getHelper<ProductHelper>();
+
             VmBindParams vmBind{};
-            vmBind.vmId = static_cast<uint32_t>(ctl.vmId);
+            vmBind.vmId = ctl.vmId;
             vmBind.flags = this->getSharedSystemBindFlags();
             vmBind.length = this->getSharedSystemAllocAddressRange();
             vmBind.sharedSystemUsmEnabled = true;
@@ -1843,6 +1855,7 @@ int Drm::createDrmVirtualMemory(uint32_t &drmVmId) {
                              "INFO:  Shared System USM capability not detected\n");
             }
         }
+
         if (ctl.vmId == 0) {
             // 0 is reserved for invalid/unassigned ppgtt
             return -1;

--- a/shared/source/os_interface/linux/ioctl_helper.h
+++ b/shared/source/os_interface/linux/ioctl_helper.h
@@ -121,6 +121,7 @@ class IoctlHelper {
     virtual bool isSetPairAvailable() = 0;
     virtual bool isChunkingAvailable() = 0;
     virtual bool isVmBindAvailable() = 0;
+    virtual bool isVmBindDecompressAvailable(uint32_t vmId) { return false; }
     virtual int createGemExt(const MemRegionsVec &memClassInstances, size_t allocSize, uint32_t &handle, uint64_t patIndex, std::optional<uint32_t> vmId, int32_t pairHandle, bool isChunked, uint32_t numOfChunks, std::optional<uint32_t> memPolicyMode, std::optional<std::vector<unsigned long>> memPolicyNodemask, std::optional<bool> isCoherent) = 0;
     virtual uint32_t createGem(uint64_t size, uint32_t memoryBanks, std::optional<bool> isCoherent) = 0;
     virtual CacheRegion closAlloc(CacheLevel cacheLevel) = 0;
@@ -144,7 +145,7 @@ class IoctlHelper {
     virtual bool getGemTiling(void *setTiling) = 0;
     virtual uint32_t getDirectSubmissionFlag() = 0;
     virtual std::unique_ptr<uint8_t[]> prepareVmBindExt(const StackVec<uint32_t, 2> &bindExtHandles, uint64_t cookie) = 0;
-    virtual uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource) = 0;
+    virtual uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource, bool resolveResource) = 0;
     virtual int queryDistances(std::vector<QueryItem> &queryItems, std::vector<DistanceInfo> &distanceInfos) = 0;
     virtual uint16_t getWaitUserFenceSoftFlag() = 0;
     virtual int execBuffer(ExecBuffer *execBuffer, uint64_t completionGpuAddress, TaskCountType counterValue) = 0;
@@ -342,7 +343,7 @@ class IoctlHelperUpstream : public IoctlHelperI915 {
     bool setVmPrefetch(uint64_t start, uint64_t length, uint32_t region, uint32_t vmId) override;
     uint32_t getDirectSubmissionFlag() override;
     std::unique_ptr<uint8_t[]> prepareVmBindExt(const StackVec<uint32_t, 2> &bindExtHandles, uint64_t cookie) override;
-    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource) override;
+    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource, bool resolveResource) override;
     int queryDistances(std::vector<QueryItem> &queryItems, std::vector<DistanceInfo> &distanceInfos) override;
     uint16_t getWaitUserFenceSoftFlag() override;
     int execBuffer(ExecBuffer *execBuffer, uint64_t completionGpuAddress, TaskCountType counterValue) override;
@@ -419,7 +420,7 @@ class IoctlHelperPrelim20 : public IoctlHelperI915 {
     bool setVmPrefetch(uint64_t start, uint64_t length, uint32_t region, uint32_t vmId) override;
     uint32_t getDirectSubmissionFlag() override;
     std::unique_ptr<uint8_t[]> prepareVmBindExt(const StackVec<uint32_t, 2> &bindExtHandles, uint64_t cookie) override;
-    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource) override;
+    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource, bool resolveResource) override;
     int queryDistances(std::vector<QueryItem> &queryItems, std::vector<DistanceInfo> &distanceInfos) override;
     uint16_t getWaitUserFenceSoftFlag() override;
     int execBuffer(ExecBuffer *execBuffer, uint64_t completionGpuAddress, TaskCountType counterValue) override;

--- a/shared/source/os_interface/linux/ioctl_helper_prelim.cpp
+++ b/shared/source/os_interface/linux/ioctl_helper_prelim.cpp
@@ -510,7 +510,7 @@ std::unique_ptr<uint8_t[]> IoctlHelperPrelim20::prepareVmBindExt(const StackVec<
     return extensionsBuffer;
 }
 
-uint64_t IoctlHelperPrelim20::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource) {
+uint64_t IoctlHelperPrelim20::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource, bool resolveResource) {
     uint64_t flags = 0u;
     if (bindCapture) {
         flags |= PRELIM_I915_GEM_VM_BIND_CAPTURE;

--- a/shared/source/os_interface/linux/ioctl_helper_upstream.cpp
+++ b/shared/source/os_interface/linux/ioctl_helper_upstream.cpp
@@ -172,7 +172,7 @@ std::unique_ptr<uint8_t[]> IoctlHelperUpstream::prepareVmBindExt(const StackVec<
     return {};
 }
 
-uint64_t IoctlHelperUpstream::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource) {
+uint64_t IoctlHelperUpstream::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLockedMemory, bool readOnlyResource, bool resolveResource) {
     return 0u;
 }
 

--- a/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
+++ b/shared/source/os_interface/linux/xe/ioctl_helper_xe.cpp
@@ -90,6 +90,8 @@ std::string IoctlHelperXe::xeGetBindFlagNames(int bindFlags) {
         return "";
     }
 
+#define DRM_XE_VM_BIND_FLAG_DECOMPRESS (1 << 7)
+
     std::string flags;
     if (bindFlags & DRM_XE_VM_BIND_FLAG_READONLY) {
         bindFlags &= ~DRM_XE_VM_BIND_FLAG_READONLY;
@@ -114,6 +116,10 @@ std::string IoctlHelperXe::xeGetBindFlagNames(int bindFlags) {
     if (bindFlags & DRM_XE_VM_BIND_FLAG_MADVISE_AUTORESET) {
         bindFlags &= ~DRM_XE_VM_BIND_FLAG_MADVISE_AUTORESET;
         flags += "MADVISE_AUTORESET ";
+    }
+    if (bindFlags & DRM_XE_VM_BIND_FLAG_DECOMPRESS) {
+        bindFlags &= ~DRM_XE_VM_BIND_FLAG_DECOMPRESS;
+        flags += "DECOMPRESS ";
     }
 
     if (bindFlags != 0) {
@@ -297,6 +303,61 @@ bool IoctlHelperXe::isChunkingAvailable() {
 
 bool IoctlHelperXe::isVmBindAvailable() {
     return true;
+}
+
+bool IoctlHelperXe::isVmBindDecompressAvailable(uint32_t vmId) {
+    std::call_once(checkVmBindDecompressOnce, [this, vmId]() {
+
+#define DRM_XE_VM_BIND_FLAG_DECOMPRESS (1 << 7)
+        auto gemRet = createGem(MemoryConstants::pageSize, 1, std::nullopt);
+
+        if (gemRet != 0) {
+            auto &rootDeviceEnvironment = drm.getRootDeviceEnvironment();
+            auto gmmHelper = rootDeviceEnvironment.getGmmHelper();
+
+            uint64_t probeAddr = MemoryConstants::pageSize;
+
+            VmBindParams probeVmBind{};
+            probeVmBind.vmId = static_cast<uint32_t>(vmId);
+            probeVmBind.handle = gemRet;
+            probeVmBind.flags = DRM_XE_VM_BIND_FLAG_IMMEDIATE | DRM_XE_VM_BIND_FLAG_DECOMPRESS;
+            probeVmBind.length = MemoryConstants::pageSize;
+            probeVmBind.start = gmmHelper->canonize(probeAddr);
+            probeVmBind.offset = 0u;
+            probeVmBind.sharedSystemUsmEnabled = false;
+            probeVmBind.sharedSystemUsmBind = false;
+            probeVmBind.extensions = 0u;
+            probeVmBind.patIndex = static_cast<uint16_t>(rootDeviceEnvironment.getGmmClientContext()->cachePolicyGetPATIndex(nullptr, GMM_RESOURCE_USAGE_OCL_BUFFER, false, false));
+
+            auto pagingFenceAddr = getPagingFenceAddress(0, nullptr);
+            VmBindExtUserFenceT probeUserFence{};
+            fillVmBindExtUserFence(probeUserFence, castToUint64(pagingFenceAddr), drm.getNextFenceVal(0), probeVmBind.extensions);
+            setVmBindUserFence(probeVmBind, probeUserFence);
+
+            auto probeRet = vmBind(probeVmBind);
+
+            if (probeRet == 0) {
+                VmBindParams probeUnbind{};
+                probeUnbind.vmId = vmId;
+                probeUnbind.start = gmmHelper->canonize(probeAddr);
+                probeUnbind.length = MemoryConstants::pageSize;
+                probeUnbind.sharedSystemUsmEnabled = false;
+                probeUnbind.extensions = 0u;
+
+                VmBindExtUserFenceT unbindUserFence{};
+                fillVmBindExtUserFence(unbindUserFence, castToUint64(getPagingFenceAddress(0, nullptr)), drm.getNextFenceVal(0), probeUnbind.extensions);
+                setVmBindUserFence(probeUnbind, unbindUserFence);
+                vmUnbind(probeUnbind);
+
+                vmBindDecompressAvailable = true;
+            }
+
+            GemClose gemClose{};
+            gemClose.handle = gemRet;
+            ioctl(DrmIoctl::gemClose, &gemClose);
+        }
+    });
+    return vmBindDecompressAvailable;
 }
 
 bool IoctlHelperXe::setDomainCpu(uint32_t handle, bool writeEnable) {
@@ -1115,9 +1176,9 @@ bool IoctlHelperXe::completionFenceExtensionSupported(const bool isVmBindAvailab
     return isVmBindAvailable;
 }
 
-uint64_t IoctlHelperXe::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLock, bool readOnlyResource) {
+uint64_t IoctlHelperXe::getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLock, bool readOnlyResource, bool resolveResource) {
     uint64_t flags = 0;
-    XELOG(" -> IoctlHelperXe::%s %d %d %d %d %d\n", __FUNCTION__, bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource);
+    XELOG(" -> IoctlHelperXe::%s %d %d %d %d %d %d\n", __FUNCTION__, bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource, resolveResource);
     if (bindCapture) {
         flags |= DRM_XE_VM_BIND_FLAG_DUMPABLE;
     }
@@ -1127,6 +1188,11 @@ uint64_t IoctlHelperXe::getFlagsForVmBind(bool bindCapture, bool bindImmediate, 
 
     if (readOnlyResource) {
         flags |= DRM_XE_VM_BIND_FLAG_READONLY;
+    }
+
+    if (resolveResource) {
+#define DRM_XE_VM_BIND_FLAG_DECOMPRESS (1 << 7)
+        flags |= DRM_XE_VM_BIND_FLAG_DECOMPRESS;
     }
     return flags;
 }
@@ -1573,6 +1639,14 @@ int IoctlHelperXe::createDrmContext(Drm &drm, OsContextLinux &osContext, uint32_
     if (ret != 0) {
         UNRECOVERABLE_IF(true);
     }
+
+    auto &rootDeviceEnvironment = drm.getRootDeviceEnvironment();
+    auto &productHelper = rootDeviceEnvironment.getProductHelper();
+    if (productHelper.isVmBindResourceDecompressionSupported()) {
+        auto ret = isVmBindDecompressAvailable(drmVmId);
+        rootDeviceEnvironment.executionEnvironment.setResourceDecompressionEnabled(ret);
+    }
+
     return drmContextId;
 }
 

--- a/shared/source/os_interface/linux/xe/ioctl_helper_xe.h
+++ b/shared/source/os_interface/linux/xe/ioctl_helper_xe.h
@@ -46,6 +46,7 @@ class IoctlHelperXe : public IoctlHelper {
     bool isSetPairAvailable() override;
     bool isChunkingAvailable() override;
     bool isVmBindAvailable() override;
+    bool isVmBindDecompressAvailable(uint32_t vmId) override;
     int createGemExt(const MemRegionsVec &memClassInstances, size_t allocSize, uint32_t &handle, uint64_t patIndex, std::optional<uint32_t> vmId, int32_t pairHandle, bool isChunked, uint32_t numOfChunks, std::optional<uint32_t> memPolicyMode, std::optional<std::vector<unsigned long>> memPolicyNodemask, std::optional<bool> isCoherent) override;
     uint32_t createGem(uint64_t size, uint32_t memoryBanks, std::optional<bool> isCoherent) override;
     CacheRegion closAlloc(CacheLevel cacheLevel) override;
@@ -69,7 +70,7 @@ class IoctlHelperXe : public IoctlHelper {
     bool getGemTiling(void *setTiling) override;
     uint32_t getDirectSubmissionFlag() override;
     std::unique_ptr<uint8_t[]> prepareVmBindExt(const StackVec<uint32_t, 2> &bindExtHandles, uint64_t cookie) override;
-    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLock, bool readOnlyResource) override;
+    uint64_t getFlagsForVmBind(bool bindCapture, bool bindImmediate, bool bindMakeResident, bool bindLock, bool readOnlyResource, bool resolveResource) override;
     virtual std::string xeGetBindFlagNames(int bindFlags);
     int queryDistances(std::vector<QueryItem> &queryItems, std::vector<DistanceInfo> &distanceInfos) override;
     uint16_t getWaitUserFenceSoftFlag() override;
@@ -205,6 +206,8 @@ class IoctlHelperXe : public IoctlHelper {
     std::mutex gemCloseLock;
     mutable std::once_flag checkDeferBackingOnce;
     mutable bool deferBackingEnabled = false;
+    mutable std::once_flag checkVmBindDecompressOnce;
+    mutable bool vmBindDecompressAvailable = false;
     std::vector<BindInfo> bindInfo;
     std::vector<uint32_t> hwconfig;
     std::vector<XeDrm::drm_xe_engine_class_instance> contextParamEngine;

--- a/shared/source/os_interface/product_helper.h
+++ b/shared/source/os_interface/product_helper.h
@@ -158,6 +158,7 @@ class ProductHelper {
     virtual bool isComputeDispatchAllWalkerEnableInCfeStateRequired(const HardwareInfo &hwInfo) const = 0;
     virtual bool adjustDispatchAllRequired(const HardwareInfo &hwInfo) const = 0;
     virtual bool isVmBindPatIndexProgrammingSupported() const = 0;
+    virtual bool isVmBindResourceDecompressionSupported() const = 0;
     virtual bool isIpSamplingSupported(const HardwareInfo &hwInfo) const = 0;
     virtual bool isGrfNumReportedWithScm() const = 0;
     virtual bool isThreadArbitrationPolicyReportedWithScm() const = 0;

--- a/shared/source/os_interface/product_helper.inl
+++ b/shared/source/os_interface/product_helper.inl
@@ -439,6 +439,11 @@ bool ProductHelperHw<gfxProduct>::isDeferBackingEnabled() const {
 }
 
 template <PRODUCT_FAMILY gfxProduct>
+bool ProductHelperHw<gfxProduct>::isVmBindResourceDecompressionSupported() const {
+    return false;
+}
+
+template <PRODUCT_FAMILY gfxProduct>
 bool ProductHelperHw<gfxProduct>::isDisableScratchPagesRequiredForDebugger() const {
     return true;
 }

--- a/shared/source/os_interface/product_helper_hw.h
+++ b/shared/source/os_interface/product_helper_hw.h
@@ -96,6 +96,7 @@ class ProductHelperHw : public ProductHelper {
     bool isComputeDispatchAllWalkerEnableInCfeStateRequired(const HardwareInfo &hwInfo) const override;
     bool adjustDispatchAllRequired(const HardwareInfo &hwInfo) const override;
     bool isVmBindPatIndexProgrammingSupported() const override;
+    bool isVmBindResourceDecompressionSupported() const override;
     bool isIpSamplingSupported(const HardwareInfo &hwInfo) const override;
     bool isGrfNumReportedWithScm() const override;
     bool isThreadArbitrationPolicyReportedWithScm() const override;

--- a/shared/source/os_interface/windows/wddm_memory_operations_handler.h
+++ b/shared/source/os_interface/windows/wddm_memory_operations_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Intel Corporation
+ * Copyright (C) 2019-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -26,6 +26,10 @@ class WddmMemoryOperationsHandler : public MemoryOperationsHandler {
     MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) override;
     MemoryOperationsStatus evict(Device *device, GraphicsAllocation &gfxAllocation) override;
     MemoryOperationsStatus isResident(Device *device, GraphicsAllocation &gfxAllocation) override;
+
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override {
+        return MemoryOperationsStatus::unsupported;
+    }
 
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override {
         return MemoryOperationsStatus::unsupported;

--- a/shared/source/release_helper/release_helper.h
+++ b/shared/source/release_helper/release_helper.h
@@ -70,7 +70,6 @@ class ReleaseHelper {
     virtual bool isPostImageWriteFlushRequired() const = 0;
     virtual uint32_t adjustMaxThreadsPerEuCount(uint32_t maxThreadsPerEuCount, uint32_t grfCount) const = 0;
     virtual bool shouldQueryPeerAccess() const = 0;
-    virtual bool isUsmCompressionSupportedOnPeerAccess() const = 0;
     virtual bool isSingleDispatchRequiredForMultiCCS() const = 0;
     virtual bool isStateCacheInvalidationWaRequired() const = 0;
     virtual bool isAvailableSemaphore64() const = 0;
@@ -121,7 +120,6 @@ class ReleaseHelperHw : public ReleaseHelper {
     bool isPostImageWriteFlushRequired() const override;
     uint32_t adjustMaxThreadsPerEuCount(uint32_t maxThreadsPerEuCount, uint32_t grfCount) const override;
     bool shouldQueryPeerAccess() const override;
-    bool isUsmCompressionSupportedOnPeerAccess() const override;
     bool isSingleDispatchRequiredForMultiCCS() const override;
     bool isStateCacheInvalidationWaRequired() const override;
     bool isAvailableSemaphore64() const override;

--- a/shared/source/release_helper/release_helper_2001.cpp
+++ b/shared/source/release_helper/release_helper_2001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Intel Corporation
+ * Copyright (C) 2024-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -52,11 +52,6 @@ bool ReleaseHelperHw<release>::programmAdditionalStallPriorToBarrierWithTimestam
 template <>
 bool ReleaseHelperHw<release>::shouldQueryPeerAccess() const {
     return true;
-}
-
-template <>
-bool ReleaseHelperHw<release>::isUsmCompressionSupportedOnPeerAccess() const {
-    return false;
 }
 
 template <>

--- a/shared/source/release_helper/release_helper_2002.cpp
+++ b/shared/source/release_helper/release_helper_2002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Intel Corporation
+ * Copyright (C) 2025-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -52,11 +52,6 @@ bool ReleaseHelperHw<release>::programmAdditionalStallPriorToBarrierWithTimestam
 template <>
 bool ReleaseHelperHw<release>::shouldQueryPeerAccess() const {
     return true;
-}
-
-template <>
-bool ReleaseHelperHw<release>::isUsmCompressionSupportedOnPeerAccess() const {
-    return false;
 }
 
 template <>

--- a/shared/source/release_helper/release_helper_base.inl
+++ b/shared/source/release_helper/release_helper_base.inl
@@ -187,11 +187,6 @@ bool ReleaseHelperHw<releaseType>::shouldQueryPeerAccess() const {
 }
 
 template <ReleaseType releaseType>
-bool ReleaseHelperHw<releaseType>::isUsmCompressionSupportedOnPeerAccess() const {
-    return true;
-}
-
-template <ReleaseType releaseType>
 bool ReleaseHelperHw<releaseType>::isSingleDispatchRequiredForMultiCCS() const {
     return false;
 }

--- a/shared/source/xe2_hpg_core/linux/product_helper_bmg.cpp
+++ b/shared/source/xe2_hpg_core/linux/product_helper_bmg.cpp
@@ -31,6 +31,11 @@ int ProductHelperHw<gfxProduct>::configureHardwareCustom(HardwareInfo *hwInfo, O
 }
 
 template <>
+bool ProductHelperHw<gfxProduct>::isVmBindResourceDecompressionSupported() const {
+    return true;
+}
+
+template <>
 bool ProductHelperHw<gfxProduct>::isDeferBackingEnabled() const {
     if (debugManager.flags.EnableDeferBacking.get() != -1) {
         return debugManager.flags.EnableDeferBacking.get();

--- a/shared/source/xe3p_core/linux/product_helper_cri.cpp
+++ b/shared/source/xe3p_core/linux/product_helper_cri.cpp
@@ -41,6 +41,11 @@ bool ProductHelperHw<gfxProduct>::isPageFaultSupported() const {
 }
 
 template <>
+bool ProductHelperHw<gfxProduct>::isVmBindResourceDecompressionSupported() const {
+    return true;
+}
+
+template <>
 uint64_t ProductHelperHw<gfxProduct>::getSharedSystemPatIndex() const {
     return 0;
 }

--- a/shared/test/common/mocks/linux/debug_mock_drm_xe.h
+++ b/shared/test/common/mocks/linux/debug_mock_drm_xe.h
@@ -37,6 +37,8 @@ struct MockIoctlHelperXeDebug : IoctlHelperXe {
     using IoctlHelperXe::getEudebugExtPropertyValue;
     using IoctlHelperXe::IoctlHelperXe;
     using IoctlHelperXe::tileIdToGtId;
+
+    bool isVmBindDecompressAvailable(uint32_t vmId) override { return false; }
 };
 
 inline constexpr int testValueVmId = 0x5764;
@@ -61,7 +63,7 @@ struct DrmMockXeDebug : public DrmMockCustom {
         drm->isVmBindAvailable();
         drm->reset();
 
-        drm->ioctlHelper = std::make_unique<IoctlHelperXe>(*drm);
+        drm->ioctlHelper = std::make_unique<MockIoctlHelperXeDebug>(*drm);
 
         auto xeQueryConfig = reinterpret_cast<drm_xe_query_config *>(drm->queryConfig);
         xeQueryConfig->num_params = 6;

--- a/shared/test/common/mocks/mock_memory_operations_handler.h
+++ b/shared/test/common/mocks/mock_memory_operations_handler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Intel Corporation
+ * Copyright (C) 2019-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,6 +21,7 @@ class MockMemoryOperationsHandler : public MemoryOperationsHandler {
   public:
     MockMemoryOperationsHandler() {}
     MemoryOperationsStatus makeResident(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence) override { return MemoryOperationsStatus::unsupported; }
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override { return MemoryOperationsStatus::unsupported; }
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override { return MemoryOperationsStatus::unsupported; }
     MemoryOperationsStatus evict(Device *device, GraphicsAllocation &gfxAllocation) override { return MemoryOperationsStatus::unsupported; }
     MemoryOperationsStatus isResident(Device *device, GraphicsAllocation &gfxAllocation) override { return MemoryOperationsStatus::unsupported; }
@@ -32,6 +33,7 @@ class MockMemoryOperationsHandlerTests : public MemoryOperationsHandler {
   public:
     MockMemoryOperationsHandlerTests() {}
     ADDMETHOD_NOBASE(makeResident, MemoryOperationsStatus, MemoryOperationsStatus::unsupported, (Device * device, ArrayRef<GraphicsAllocation *> gfxAllocations, bool isDummyExecNeeded, const bool forcePagingFence));
+    ADDMETHOD_NOBASE(decompress, MemoryOperationsStatus, MemoryOperationsStatus::unsupported, (Device * device, GraphicsAllocation &gfxAllocation));
     ADDMETHOD_NOBASE(lock, MemoryOperationsStatus, MemoryOperationsStatus::unsupported, (Device * device, ArrayRef<GraphicsAllocation *> gfxAllocations));
     ADDMETHOD_NOBASE(evict, MemoryOperationsStatus, MemoryOperationsStatus::unsupported, (Device * device, GraphicsAllocation &gfxAllocation));
     ADDMETHOD_NOBASE(isResident, MemoryOperationsStatus, MemoryOperationsStatus::unsupported, (Device * device, GraphicsAllocation &gfxAllocation));
@@ -54,6 +56,10 @@ class MockMemoryOperations : public MemoryOperationsHandler {
             }
         }
         return MemoryOperationsStatus::success;
+    }
+
+    MemoryOperationsStatus decompress(Device *device, GraphicsAllocation &gfxAllocation) override {
+        return MemoryOperationsStatus::unsupported;
     }
 
     MemoryOperationsStatus lock(Device *device, ArrayRef<GraphicsAllocation *> gfxAllocations) override {

--- a/shared/test/common/mocks/mock_release_helper.h
+++ b/shared/test/common/mocks/mock_release_helper.h
@@ -46,7 +46,6 @@ class MockReleaseHelper : public ReleaseHelper {
     ADDMETHOD_CONST_NOBASE(adjustMaxThreadsPerEuCount, uint32_t, 8u, (uint32_t maxThreadsPerEuCount, uint32_t grfCount));
     ADDMETHOD_CONST_NOBASE_VOIDRETURN(adjustRTDispatchGlobals, (void *rtDispatchGlobals, uint32_t rtStacksPerDss, bool heaplessEnabled, uint32_t maxBvhLevels));
     ADDMETHOD_CONST_NOBASE(shouldQueryPeerAccess, bool, false, ());
-    ADDMETHOD_CONST_NOBASE(isUsmCompressionSupportedOnPeerAccess, bool, true, ());
     ADDMETHOD_CONST_NOBASE(isSingleDispatchRequiredForMultiCCS, bool, false, ());
     ADDMETHOD_CONST_NOBASE(isStateCacheInvalidationWaRequired, bool, false, ());
     ADDMETHOD_CONST_NOBASE(isAvailableSemaphore64, bool, false, ());

--- a/shared/test/common/os_interface/linux/xe/mock_ioctl_helper_xe.h
+++ b/shared/test/common/os_interface/linux/xe/mock_ioctl_helper_xe.h
@@ -73,6 +73,8 @@ struct MockIoctlHelperXe : IoctlHelperXe {
         return IoctlHelperXe::ioctl(fd, request, arg);
     }
 
+    bool isVmBindDecompressAvailable(uint32_t vmId) override { return false; }
+
     void testLog(auto &&...args) {
         XELOG(args...);
     }

--- a/shared/test/unit_test/execution_environment/execution_environment_tests.cpp
+++ b/shared/test/unit_test/execution_environment/execution_environment_tests.cpp
@@ -442,14 +442,14 @@ static_assert(sizeof(ExecutionEnvironment) == sizeof(std::unique_ptr<MemoryManag
                                                   sizeof(std::unordered_map<uint32_t, std::tuple<uint32_t, uint32_t, uint32_t>>) +
                                                   sizeof(std::unordered_map<std::thread::id, std::string>) +
                                                   2 * sizeof(std::mutex) +
-                                                  2 * sizeof(bool) +
+                                                  5 * sizeof(bool) +
                                                   sizeof(DeviceHierarchyMode) +
                                                   sizeof(DebuggingMode) +
                                                   sizeof(std::unordered_map<uint32_t, uint32_t>) +
                                                   sizeof(std::mutex) +
                                                   sizeof(std::vector<std::tuple<std::string, uint32_t>>) +
                                                   sizeof(std::mutex) +
-                                                  (is64bit ? 22 : 14),
+                                                  (is64bit ? 19 : 15),
               "New members detected in ExecutionEnvironment, please ensure that destruction sequence of objects is correct");
 
 TEST(ExecutionEnvironment, givenExecutionEnvironmentWithVariousMembersWhenItIsDestroyedThenDeleteSequenceIsSpecified) {
@@ -781,6 +781,18 @@ TEST(ExecutionEnvironment, givenExecutionEnvironmentWhenSetDevicePermissionError
 
     executionEnvironment.setDevicePermissionError(false);
     EXPECT_FALSE(executionEnvironment.isDevicePermissionError());
+}
+
+TEST(ExecutionEnvironment, givenExecutionEnvironmentWhenSetResourceDecompressionEnabledIsCalledThenCorrectValueIsReturned) {
+    MockExecutionEnvironment executionEnvironment;
+
+    EXPECT_FALSE(executionEnvironment.isResourceDecompressionEnabled());
+
+    executionEnvironment.setResourceDecompressionEnabled(true);
+    EXPECT_TRUE(executionEnvironment.isResourceDecompressionEnabled());
+
+    executionEnvironment.setResourceDecompressionEnabled(false);
+    EXPECT_FALSE(executionEnvironment.isResourceDecompressionEnabled());
 }
 
 TEST(ExecutionEnvironment, givenExecutionEnvironmentWhenCcsNumberIsValidThenAdjustCcsCountReturnsTrue) {

--- a/shared/test/unit_test/os_interface/aub_memory_operations_handler_tests.cpp
+++ b/shared/test/unit_test/os_interface/aub_memory_operations_handler_tests.cpp
@@ -603,3 +603,14 @@ HWTEST_F(AubMemoryOperationsHandlerTests, givenGfxAllocationWriteableWithGmmPres
     EXPECT_TRUE(aubManager->storedAllocationParams[0].additionalParams.compressionEnabled);
     EXPECT_FALSE(aubManager->storedAllocationParams[0].additionalParams.uncached);
 }
+
+TEST_F(AubMemoryOperationsHandlerTests, givenRegularAllocationWhenDecompressingAllocationThenUnsupportIsReturned) {
+    MockAubManager aubManager;
+    getMemoryOperationsHandler()->setAubManager(&aubManager);
+    auto memoryOperationsInterface = getMemoryOperationsHandler();
+
+    MemoryAllocation allocation(0, 1u /*num gmms*/, AllocationType::unknown, nullptr, reinterpret_cast<void *>(0x1000), 0x1000u,
+                                MemoryConstants::pageSize, 0, MemoryPool::localMemory, false, false, MemoryManager::maxOsContextCount);
+
+    EXPECT_EQ(memoryOperationsInterface->decompress(nullptr, allocation), MemoryOperationsStatus::unsupported);
+}

--- a/shared/test/unit_test/os_interface/linux/drm_memory_operations_handler_bind_tests.cpp
+++ b/shared/test/unit_test/os_interface/linux/drm_memory_operations_handler_bind_tests.cpp
@@ -1436,6 +1436,36 @@ TEST_F(DrmMemoryOperationsHandlerBindTest, givenDrmMemoryOperationBindWhenCallin
     memoryManager->freeGraphicsMemory(allocation);
 }
 
+TEST_F(DrmMemoryOperationsHandlerBindTest, givenMultipleBufferObjectsAllocationWhenDecompressCalledThenDecompressFlagsAreCleared) {
+    DebugManagerStateRestore restorer;
+    debugManager.flags.EnableLocalMemory.set(1);
+
+    BufferObjects bos;
+    MockBufferObject mockBo1(0, mock, 3, 0, 0, 1), mockBo2(0, mock, 3, 0, 0, 1);
+    mockBo1.setSize(1024);
+    mockBo2.setSize(1024);
+    mockBo1.requireResourceDecompress(true);
+    mockBo2.requireResourceDecompress(true);
+    bos.push_back(&mockBo1);
+    bos.push_back(&mockBo2);
+    GraphicsAllocation *mockDrmAllocation = new MockDrmAllocation(AllocationType::unknown, MemoryPool::localMemory, bos);
+    mockDrmAllocation->storageInfo.memoryBanks = 3;
+    EXPECT_EQ(2u, mockDrmAllocation->storageInfo.getNumBanks());
+
+    auto drmAllocation = static_cast<DrmAllocation *>(mockDrmAllocation);
+
+    auto status = operationHandler->decompress(device, *mockDrmAllocation);
+    EXPECT_EQ(MemoryOperationsStatus::success, status);
+
+    for (uint32_t vmHandleId = 0; vmHandleId < drmAllocation->getBOs().size(); vmHandleId++) {
+        auto bo = drmAllocation->getBOs()[vmHandleId];
+        if (bo) {
+            EXPECT_FALSE(bo->isResourceDecompressRequired());
+        }
+    }
+    delete mockDrmAllocation;
+}
+
 using DrmResidencyHandlerTests = ::testing::Test;
 
 HWTEST2_F(DrmResidencyHandlerTests, givenClosIndexAndMemoryTypeWhenAskingForPatIndexThenReturnCorrectValue, IsXeCore) {

--- a/shared/test/unit_test/os_interface/linux/drm_memory_operations_handler_default_tests.cpp
+++ b/shared/test/unit_test/os_interface/linux/drm_memory_operations_handler_default_tests.cpp
@@ -221,6 +221,11 @@ TEST_F(DrmMemoryOperationsHandlerBaseTest, givenOperationsHandlerWhenFlushReturn
     EXPECT_EQ(drmMemoryOperationsHandler->evictWithinOsContextCalled, 0u);
 }
 
+TEST_F(DrmMemoryOperationsHandlerBaseTest, givenRegularAllocationWhenDecompressingAllocationThenUnsupportIsReturned) {
+    initializeAllocation(1);
+    EXPECT_EQ(drmMemoryOperationsHandler->decompress(nullptr, *allocationPtr), MemoryOperationsStatus::unsupported);
+}
+
 struct DrmMemoryOperationsHandlerBaseTestFlushDummyExec : public DrmMemoryOperationsHandlerBaseTest {
     using BaseClass = DrmMemoryOperationsHandlerBaseTest;
     void SetUp() override {

--- a/shared/test/unit_test/os_interface/linux/ioctl_helper_tests_prelim.cpp
+++ b/shared/test/unit_test/os_interface/linux/ioctl_helper_tests_prelim.cpp
@@ -283,7 +283,7 @@ TEST_F(IoctlPrelimHelperTests, whenGettingFlagsForVmBindThenProperValuesAreRetur
             for (auto &bindMakeResident : ::testing::Bool()) {
                 for (auto &bindLockedMemory : ::testing::Bool()) {
                     for (auto &readOnlyResource : ::testing::Bool()) {
-                        auto flags = ioctlHelper.getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLockedMemory, readOnlyResource);
+                        auto flags = ioctlHelper.getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLockedMemory, readOnlyResource, false);
                         if (bindCapture) {
                             EXPECT_EQ(PRELIM_I915_GEM_VM_BIND_CAPTURE, (flags & PRELIM_I915_GEM_VM_BIND_CAPTURE));
                         }

--- a/shared/test/unit_test/os_interface/linux/ioctl_helper_tests_upstream.cpp
+++ b/shared/test/unit_test/os_interface/linux/ioctl_helper_tests_upstream.cpp
@@ -331,8 +331,10 @@ TEST(IoctlHelperUpstreamTest, whenGettingFlagsForVmBindThenZeroIsReturned) {
             for (auto &bindMakeResident : ::testing::Bool()) {
                 for (auto &bindLock : ::testing::Bool()) {
                     for (auto &readOnlyResource : ::testing::Bool()) {
-                        auto flags = ioctlHelper.getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource);
-                        EXPECT_EQ(0u, flags);
+                        for (auto &resolveResource : ::testing::Bool()) {
+                            auto flags = ioctlHelper.getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLock, readOnlyResource, resolveResource);
+                            EXPECT_EQ(0u, flags);
+                        }
                     }
                 }
             }

--- a/shared/test/unit_test/os_interface/linux/xe/ioctl_helper_xe_tests.cpp
+++ b/shared/test/unit_test/os_interface/linux/xe/ioctl_helper_xe_tests.cpp
@@ -528,7 +528,7 @@ TEST_F(IoctlHelperXeTest, givenIoctlHelperXeWhenCallingAnyMethodThenDummyValueIs
 
     EXPECT_EQ(0u, xeIoctlHelper->getDirectSubmissionFlag());
 
-    EXPECT_EQ(0u, xeIoctlHelper->getFlagsForVmBind(false, false, false, false, false));
+    EXPECT_EQ(0u, xeIoctlHelper->getFlagsForVmBind(false, false, false, false, false, false));
 
     std::vector<QueryItem> queryItems;
     std::vector<DistanceInfo> distanceInfos;
@@ -697,8 +697,8 @@ TEST_F(IoctlHelperXeTest, whenGettingFlagsForVmBindThenPropertValueIsReturned) {
     DrmMock drm{*executionEnvironment->rootDeviceEnvironments[0]};
     auto xeIoctlHelper = std::make_unique<IoctlHelperXe>(drm);
 
-    EXPECT_EQ(static_cast<uint64_t>(DRM_XE_VM_BIND_FLAG_DUMPABLE), xeIoctlHelper->getFlagsForVmBind(true, false, false, false, false));
-    EXPECT_EQ(static_cast<uint64_t>(0), xeIoctlHelper->getFlagsForVmBind(false, false, false, false, false));
+    EXPECT_EQ(static_cast<uint64_t>(DRM_XE_VM_BIND_FLAG_DUMPABLE), xeIoctlHelper->getFlagsForVmBind(true, false, false, false, false, false));
+    EXPECT_EQ(static_cast<uint64_t>(0), xeIoctlHelper->getFlagsForVmBind(false, false, false, false, false, false));
 }
 
 TEST_F(IoctlHelperXeTest, whenGettingIoctlRequestValueThenPropertValueIsReturned) {
@@ -2784,12 +2784,14 @@ TEST_F(IoctlHelperXeTest, givenIoctlHelperXeWhenCallingGetFlagsForVmBindThenExpe
             for (auto &bindMakeResident : ::testing::Bool()) {
                 for (auto &bindLockedMemory : ::testing::Bool()) {
                     for (auto &readOnlyResource : ::testing::Bool()) {
-                        auto flags = xeIoctlHelper->getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLockedMemory, readOnlyResource);
-                        if (bindCapture) {
-                            EXPECT_EQ(static_cast<uint32_t>(DRM_XE_VM_BIND_FLAG_DUMPABLE), (flags & DRM_XE_VM_BIND_FLAG_DUMPABLE));
-                        }
-                        if (flags == 0) {
-                            EXPECT_FALSE(bindCapture);
+                        for (auto &resolveResource : ::testing::Bool()) {
+                            auto flags = xeIoctlHelper->getFlagsForVmBind(bindCapture, bindImmediate, bindMakeResident, bindLockedMemory, readOnlyResource, resolveResource);
+                            if (bindCapture) {
+                                EXPECT_EQ(static_cast<uint32_t>(DRM_XE_VM_BIND_FLAG_DUMPABLE), (flags & DRM_XE_VM_BIND_FLAG_DUMPABLE));
+                            }
+                            if (flags == 0) {
+                                EXPECT_FALSE(bindCapture);
+                            }
                         }
                     }
                 }
@@ -2823,6 +2825,7 @@ TEST_F(IoctlHelperXeTest, whenCheckingGpuHangThenBanPropertyIsQueried) {
 }
 
 TEST_F(IoctlHelperXeTest, givenImmediateAndReadOnlyBindFlagsSupportedWhenGettingFlagsForVmBindThenCorrectFlagsAreReturned) {
+#define DRM_XE_VM_BIND_FLAG_DECOMPRESS (1 << 7)
 
     auto executionEnvironment = std::make_unique<MockExecutionEnvironment>();
     auto drm = DrmMockXe::create(*executionEnvironment->rootDeviceEnvironments[0]);
@@ -2832,21 +2835,26 @@ TEST_F(IoctlHelperXeTest, givenImmediateAndReadOnlyBindFlagsSupportedWhenGetting
     for (const auto &bindImmediateSupport : ::testing::Bool()) {
         for (const auto &bindReadOnlySupport : ::testing::Bool()) {
             for (const auto &bindMakeResidentSupport : ::testing::Bool()) {
-                uint64_t expectedFlags = DRM_XE_VM_BIND_FLAG_DUMPABLE;
+                for (const auto &bindResolveSupport : ::testing::Bool()) {
+                    uint64_t expectedFlags = DRM_XE_VM_BIND_FLAG_DUMPABLE;
 
-                if (bindImmediateSupport) {
-                    expectedFlags |= DRM_XE_VM_BIND_FLAG_IMMEDIATE;
-                }
-                if (bindReadOnlySupport) {
-                    expectedFlags |= DRM_XE_VM_BIND_FLAG_READONLY;
-                }
-                if (bindMakeResidentSupport) {
-                    expectedFlags |= DRM_XE_VM_BIND_FLAG_IMMEDIATE;
-                }
+                    if (bindImmediateSupport) {
+                        expectedFlags |= DRM_XE_VM_BIND_FLAG_IMMEDIATE;
+                    }
+                    if (bindReadOnlySupport) {
+                        expectedFlags |= DRM_XE_VM_BIND_FLAG_READONLY;
+                    }
+                    if (bindMakeResidentSupport) {
+                        expectedFlags |= DRM_XE_VM_BIND_FLAG_IMMEDIATE;
+                    }
+                    if (bindResolveSupport) {
+                        expectedFlags |= DRM_XE_VM_BIND_FLAG_DECOMPRESS;
+                    }
 
-                auto bindFlags = xeIoctlHelper->getFlagsForVmBind(true, bindImmediateSupport, bindMakeResidentSupport, false, bindReadOnlySupport);
+                    auto bindFlags = xeIoctlHelper->getFlagsForVmBind(true, bindImmediateSupport, bindMakeResidentSupport, false, bindReadOnlySupport, bindResolveSupport);
 
-                EXPECT_EQ(expectedFlags, bindFlags);
+                    EXPECT_EQ(expectedFlags, bindFlags);
+                }
             }
         }
     }
@@ -3923,7 +3931,7 @@ TEST_F(IoctlHelperXeTest, givenContextGroupEnabledWhenCreatingPrimaryDrmContextT
     auto executionEnvironment = std::make_unique<MockExecutionEnvironment>();
     auto drm = DrmMockXe::create(*executionEnvironment->rootDeviceEnvironments[0]);
 
-    drm->ioctlHelper = std::make_unique<IoctlHelperXe>(*drm);
+    drm->ioctlHelper = std::make_unique<MockIoctlHelperXe>(*drm);
     drm->ioctlHelper->initialize();
     drm->memoryInfoQueried = true;
     drm->queryEngineInfo();
@@ -3945,7 +3953,7 @@ TEST_F(IoctlHelperXeTest, givenContextGroupEnabledWhenCreatingSecondaryDrmContex
     auto executionEnvironment = std::make_unique<MockExecutionEnvironment>();
     auto drm = DrmMockXe::create(*executionEnvironment->rootDeviceEnvironments[0]);
 
-    drm->ioctlHelper = std::make_unique<IoctlHelperXe>(*drm);
+    drm->ioctlHelper = std::make_unique<MockIoctlHelperXe>(*drm);
     drm->ioctlHelper->initialize();
     drm->memoryInfoQueried = true;
     drm->queryEngineInfo();
@@ -3971,7 +3979,7 @@ TEST_F(IoctlHelperXeTest, givenContextGroupEnabledWhenCreatingHighPriorityDrmCon
     auto executionEnvironment = std::make_unique<MockExecutionEnvironment>();
     auto drm = DrmMockXe::create(*executionEnvironment->rootDeviceEnvironments[0]);
 
-    drm->ioctlHelper = std::make_unique<IoctlHelperXe>(*drm);
+    drm->ioctlHelper = std::make_unique<MockIoctlHelperXe>(*drm);
     drm->ioctlHelper->initialize();
     drm->memoryInfoQueried = true;
     drm->queryEngineInfo();

--- a/shared/test/unit_test/os_interface/windows/wddm_memory_operations_handler_with_aub_dump_tests.cpp
+++ b/shared/test/unit_test/os_interface/windows/wddm_memory_operations_handler_with_aub_dump_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Intel Corporation
+ * Copyright (C) 2023-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -146,4 +146,8 @@ TEST_F(WddmMemoryOperationsHandlerWithAubDumpTest, whenConstructingWddmMemoryOpe
 
 TEST_F(WddmMemoryOperationsHandlerWithAubDumpTest, givenRegularAllocationWhenLockingAllocationThenUnsupportIsReturned) {
     EXPECT_EQ(wddmMemoryOperationsHandlerWithAubDumpMock->lock(nullptr, ArrayRef<GraphicsAllocation *>(&allocationPtr, 1)), MemoryOperationsStatus::unsupported);
+}
+
+TEST_F(WddmMemoryOperationsHandlerWithAubDumpTest, givenRegularAllocationWhenDecompressingAllocationThenUnsupportIsReturned) {
+    EXPECT_EQ(wddmMemoryOperationsHandlerWithAubDumpMock->decompress(nullptr, *allocationPtr), MemoryOperationsStatus::unsupported);
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_55_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_55_tests.cpp
@@ -132,10 +132,6 @@ TEST_F(ReleaseHelper1255Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1255Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1255Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_56_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_56_tests.cpp
@@ -126,10 +126,6 @@ TEST_F(ReleaseHelper1256Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1256Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1256Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_57_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_57_tests.cpp
@@ -126,10 +126,6 @@ TEST_F(ReleaseHelper1257Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1257Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1257Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_60_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_60_tests.cpp
@@ -111,10 +111,6 @@ TEST_F(ReleaseHelper1260Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1260Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1260Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_61_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_61_tests.cpp
@@ -110,10 +110,6 @@ TEST_F(ReleaseHelper1261Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1261Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1261Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_70_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_70_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper1270Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1270Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1270Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_71_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_71_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper1271Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1271Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1271Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_12_74_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_12_74_tests.cpp
@@ -126,10 +126,6 @@ TEST_F(ReleaseHelper1274Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper1274Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper1274Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_20_01_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_20_01_tests.cpp
@@ -119,10 +119,6 @@ TEST_F(ReleaseHelper2001Tests, whenShouldQueryPeerAccessCalledThenTrueReturned) 
     whenShouldQueryPeerAccessCalledThenTrueReturned();
 }
 
-TEST_F(ReleaseHelper2001Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned();
-}
-
 TEST_F(ReleaseHelper2001Tests, whenIsSingleDispatchRequiredForMultiCCSThenTrueReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenTrueReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_20_02_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_20_02_tests.cpp
@@ -119,10 +119,6 @@ TEST_F(ReleaseHelper2002Tests, whenShouldQueryPeerAccessCalledThenTrueReturned) 
     whenShouldQueryPeerAccessCalledThenTrueReturned();
 }
 
-TEST_F(ReleaseHelper2002Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned();
-}
-
 TEST_F(ReleaseHelper2002Tests, whenIsSingleDispatchRequiredForMultiCCSThenTrueReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenTrueReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_20_04_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_20_04_tests.cpp
@@ -122,10 +122,6 @@ TEST_F(ReleaseHelper2004Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper2004Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper2004Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_30_00_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_30_00_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper3000Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper3000Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper3000Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_30_01_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_30_01_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper3001Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper3001Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper3001Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_30_03_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_30_03_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper3003Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper3003Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper3003Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_30_04_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_30_04_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper3004Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper3004Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper3004Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_30_05_tests.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_30_05_tests.cpp
@@ -120,10 +120,6 @@ TEST_F(ReleaseHelper3005Tests, whenShouldQueryPeerAccessCalledThenFalseReturned)
     whenShouldQueryPeerAccessCalledThenFalseReturned();
 }
 
-TEST_F(ReleaseHelper3005Tests, whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned) {
-    whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
-}
-
 TEST_F(ReleaseHelper3005Tests, whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned) {
     whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
 }

--- a/shared/test/unit_test/release_helper/release_helper_tests_base.cpp
+++ b/shared/test/unit_test/release_helper/release_helper_tests_base.cpp
@@ -216,24 +216,6 @@ void ReleaseHelperTestsBase::whenShouldQueryPeerAccessCalledThenTrueReturned() {
     }
 }
 
-void ReleaseHelperTestsBase::whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned() {
-    for (auto &revision : getRevisions()) {
-        ipVersion.revision = revision;
-        releaseHelper = ReleaseHelper::create(ipVersion);
-        ASSERT_NE(nullptr, releaseHelper);
-        EXPECT_FALSE(releaseHelper->isUsmCompressionSupportedOnPeerAccess());
-    }
-}
-
-void ReleaseHelperTestsBase::whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned() {
-    for (auto &revision : getRevisions()) {
-        ipVersion.revision = revision;
-        releaseHelper = ReleaseHelper::create(ipVersion);
-        ASSERT_NE(nullptr, releaseHelper);
-        EXPECT_TRUE(releaseHelper->isUsmCompressionSupportedOnPeerAccess());
-    }
-}
-
 void ReleaseHelperTestsBase::whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned() {
     for (auto &revision : getRevisions()) {
         ipVersion.revision = revision;

--- a/shared/test/unit_test/release_helper/release_helper_tests_base.h
+++ b/shared/test/unit_test/release_helper/release_helper_tests_base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Intel Corporation
+ * Copyright (C) 2023-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,8 +40,6 @@ struct ReleaseHelperTestsBase : public ::testing::Test {
     void whenCallingAdjustMaxThreadsPerEuCountThenCorrectValueIsReturned();
     void whenShouldQueryPeerAccessCalledThenFalseReturned();
     void whenShouldQueryPeerAccessCalledThenTrueReturned();
-    void whenIsUsmCompressionSupportedOnPeerAccessCalledThenFalseReturned();
-    void whenIsUsmCompressionSupportedOnPeerAccessCalledThenTrueReturned();
     void whenIsSingleDispatchRequiredForMultiCCSCalledThenFalseReturned();
     void whenIsSingleDispatchRequiredForMultiCCSCalledThenTrueReturned();
     void whenIsStateCacheInvalidationWaRequiredCalledThenFalseReturned();


### PR DESCRIPTION
Add in-place resource decompression via memory operations.

- Detect DRM_XE_VM_BIND_FLAG_DECOMPRESS support at DRM init
- Decompress resources in-place for peer-to-peer access when supported
- Otherwise, allocate uncompressed memory

Depends on: https://patchwork.freedesktop.org/series/154714/