### PR TITLE
fix(sysman): update enum bounds check on eventRegister

### DIFF
--- a/level_zero/tools/source/sysman/events/linux/os_events_imp.cpp
+++ b/level_zero/tools/source/sysman/events/linux/os_events_imp.cpp
@@ -32,7 +32,7 @@ bool LinuxEventsImp::eventListen(zes_event_type_flags_t &pEvent, uint64_t timeou
 }
 
 ze_result_t LinuxEventsImp::eventRegister(zes_event_type_flags_t events) {
-    if (0x7fff < events) {
+    if (0xffff < events) {
         return ZE_RESULT_ERROR_INVALID_ENUMERATION;
     }
 


### PR DESCRIPTION
Don't error out if the caller registers for
ZES_EVENT_TYPE_FLAG_SURVIVABILITY_MODE_DETECTED event. The value is defined in the API so it's not an invalid enumeration.