### PR TITLE
fix: disable USM compression for any multi-device context

### DIFF
--- a/shared/source/memory_manager/unified_memory_manager.cpp
+++ b/shared/source/memory_manager/unified_memory_manager.cpp
@@ -525,9 +525,10 @@ void *SVMAllocsManager::createUnifiedMemoryAllocation(size_t size,
     AllocationType allocationType = getGraphicsAllocationTypeAndCompressionPreference(memoryProperties, compressionEnabled);
 
     bool preferCompressed = true;
+    const bool multiDeviceContext = (memoryProperties.rootDeviceIndices.size() > 1);
     if (compressionEnabled && memoryProperties.device) {
         if (not memoryProperties.device->getExecutionEnvironment()->isResourceDecompressionEnabled() &&
-            memoryProperties.device->hasAnyPeerAccess().value_or(false)) {
+            (memoryProperties.device->hasAnyPeerAccess().value_or(false) || multiDeviceContext)) {
             preferCompressed = false;
         }
     }


### PR DESCRIPTION
## Summary

Closes #921 

The peer-USM compression guard in `SVMAllocsManager::createUnifiedMemoryAllocation` is gated on `device->hasAnyPeerAccess().value_or(false)`. For the first USM device allocation in a multi-device L0 context that `std::optional` can be observed as `Some(false)` (peer-access cache not yet populated by `initializePeerAccessForDevices`). The disable arm is skipped, the BO is allocated compressed, and any later peer-import returns garbage through dma-buf because the importing device has no matching surface metadata.

This patch adds `memoryProperties.rootDeviceIndices.size() > 1` as an additional, synchronously-known gate. Multi-device contexts conservatively disable compression, correct because a BO in a multi-device context can become peer-imported at any subsequent point in the application's lifetime.

## Verification

- 2× and 4x Intel Arc Pro B70 (BMG-G31), Linux 7.1-rc4 + xe (with Leon Romanovsky's "dma-buf: Always build with DMABUF_MOVE_NOTIFY")
- Built locally with the patch loaded via `LD_LIBRARY_PATH` against compute-runtime 26.05/26.18, cross-device `sycl::queue::memcpy(host, peer_usm_ptr)` returned garbage before; returns source data correctly after
- Cause-and-effect confirmed by reverting the patch on the same build, returns to garbage
- The OpenCL `UNRECOVERABLE_IF(!allocation)` at `enqueue_svm.h:308` symptom on the same workload is resolved by this fix
- llama.cpp tensor-split (`--device SYCL0,SYCL1 --split-mode layer`) regression-tested on both patched and stock, no behavioural change there (that workload's allocation timing happens to dodge the race)

> Note: This patch remains necessary even on kernels with DRM_XE_VM_BIND_FLAG_DECOMPRESS (7.1-rc1+).
> The kernel-side xe_bo_decompress() at drivers/gpu/drm/xe/xe_bo.c:3537 silently skips non-VRAM buffers, and 
> peer-imported BOs are ttm_bo_type_sg, so cross-device decompression is a no-op even when the flag is 
> accepted. Until that's addressed kernel-side, disabling compression at allocation time for multi-device 
> contexts is the correct behaviour.

## Unit tests

Not added in this commit. The targeted code path requires a platform where `releaseHelper->isUsmCompressionSupportedOnPeerAccess()` returns false (release2001 / release2002 = BMG / LNL) AND `usmCompressionSupported(hwInfo)` returns true. The default `MockReleaseHelper` returns true for the former, so a test under `shared/test/unit_test/memory_manager/` would skip on most configurations.

A natural home would be `shared/test/unit_test/xe2_hpg_core/` which already uses the BMG release helper, or a new test using `MockReleaseHelper` overrides. If really needed, I could add it, would appreciate guidance on the preferred location and pattern (the existing `givenLocalMemoryEnabledAndCompressionEnabledThenDeviceSideSharedUsmIsCompressed` test in `unified_memory_manager_tests.cpp:721` is the natural sibling but uses single-root setup).

## Related

- vllm-project/vllm#41663 (same hardware, downstream symptom on TP=2)
- #916 (USM device alloc fails on dual A770 L0 context)
- #921 (multi-BMG L0 device enumeration)
- #922 (BMG multi-rank MPI + L0 crash)
- Kernel-side prerequisite (`xe_dma_buf_pin -EINVAL` on peer-imported BO) fixed upstream by Leon Romanovsky's "dma-buf: Always build with DMABUF_MOVE_NOTIFY", in mainline Linux 7.1.

cc @ivysochyn — this directly extends the guard you added in dc85f33e49 and refactored in a832f0182b. Race observed where hasAnyPeerAccess() is Some(false) for the very first multi-device alloc.
