### PR TITLE
documentation(ocloc): fix outdated device in --help example

### DIFF
--- a/shared/offline_compiler/source/ocloc_interface.cpp
+++ b/shared/offline_compiler/source/ocloc_interface.cpp
@@ -76,20 +76,20 @@ Commands:
 Default command (when none provided) is 'compile'.
 
 Examples:
-  Compile file to Intel Compute GPU device binary (out = source_file_Gen9core.bin)
-    ocloc -file source_file.cl -device skl
+  Compile file to Intel Compute GPU device binary (out = source_file_xe3_lpg.bin)
+    ocloc -file source_file.cl -device ptl-h
 
   Link two SPIR-V files.
     ocloc link -file sample1.spv -file sample2.spv -out_format LLVM_BC -out samples_merged.llvm_bc
 
   Disassemble Intel Compute GPU device binary
-    ocloc disasm -file source_file_Gen9core.bin
+    ocloc disasm -file source_file_xe3_lpg.bin
 
   Assemble to Intel Compute GPU device binary (after above disasm)
     ocloc asm -out reassembled.bin
 
   Validate Intel Compute GPU device binary
-    ocloc validate -file source_file_Gen9core.bin
+    ocloc validate -file source_file_xe3_lpg.bin
 
   Extract driver version
     ocloc query OCL_DRIVER_VERSION

--- a/shared/offline_compiler/source/offline_compiler.cpp
+++ b/shared/offline_compiler/source/offline_compiler.cpp
@@ -1755,8 +1755,8 @@ Usage: ocloc [compile] -file <filename> -device <device_type> [-output <filename
                                             Example: 0: 32505859
 %s
 Examples :
-  Compile file to Intel Compute GPU device binary (out = source_file_Gen9core.bin)
-    ocloc -file source_file.cl -device skl
+  Compile file to Intel Compute GPU device binary (out = source_file_xe3_lpg.bin)
+    ocloc -file source_file.cl -device ptl-h
 )OCLOC_HELP",
                       getSupportedDevices(argHelper).c_str(),
                       getDeprecatedDevices(argHelper).c_str(),


### PR DESCRIPTION
The compile --help example referenced 'skl', which is no longer a supported ocloc device, and an out filename that doesn't match. Update the example to use 'ptl-h' and the corresponding 'source_file_xe3_lpg.bin' output name.