### PR TITLE
fix(l0): re-initialize driver in forked child processes

### DIFF
--- a/level_zero/core/source/driver/driver.cpp
+++ b/level_zero/core/source/driver/driver.cpp
@@ -19,11 +19,37 @@
 #include "level_zero/tools/source/metrics/metric.h"
 
 #include <mutex>
+#include <pthread.h>
 
 namespace L0 {
 
 std::vector<_ze_driver_handle_t *> *globalDriverHandles;
 bool levelZeroDriverInitialized = false;
+std::mutex driverInitMutex;
+
+// Fork safety: reset driver state in child process
+static void driverForkChildHandler() {
+    // Reset the PID to force re-initialization
+    if (Driver::get()) {
+        Driver::get()->setPid(0);
+    }
+
+    // Mark all inherited driver handles as orphaned
+    // They contain stale DRM file descriptors that belong to the parent
+    if (globalDriverHandles) {
+        for (auto *handle : *globalDriverHandles) {
+            if (handle) {
+                auto *driverHandle = DriverHandle::fromHandle(handle);
+                if (driverHandle) {
+                    driverHandle->isOrphanedFromFork = true;
+                }
+            }
+        }
+    }
+
+    // Reset initialization state to allow re-init in child
+    levelZeroDriverInitialized = false;
+}
 
 void Driver::initialize(ze_result_t *result) {
     *result = ZE_RESULT_ERROR_UNINITIALIZED;
@@ -60,6 +86,19 @@ void Driver::initialize(ze_result_t *result) {
 
     executionEnvironment->setMetricsEnabled(envVariables.metrics);
     executionEnvironment->setOneApiPvcWaEnv(oneApiPvcWa);
+
+    // Fork safety: drop handles inherited from the parent before creating new ones.
+    // They are intentionally leaked, never deleted: the child shares the parent's DRM
+    // file descriptions, so destructor teardown (GEM close, context destroy ioctls)
+    // would destroy the parent's GPU objects. Same policy as globalDriverTeardown(),
+    // which only deletes handles whose pid matches the current process.
+    if (globalDriverHandles && !globalDriverHandles->empty()) {
+        auto currentPid = NEO::SysCalls::getCurrentProcessId();
+        std::erase_if(*globalDriverHandles, [currentPid](_ze_driver_handle_t *handle) {
+            auto *driverHandle = DriverHandle::fromHandle(handle);
+            return driverHandle && (driverHandle->isOrphanedFromFork || driverHandle->pid != currentPid);
+        });
+    }
 
     executionEnvironment->incRefInternal();
     auto neoDevices = NEO::DeviceFactory::createDevices(*executionEnvironment);
@@ -120,11 +159,35 @@ ze_result_t Driver::driverInit() {
 }
 
 ze_result_t Driver::driverHandleGet(uint32_t *pCount, ze_driver_handle_t *phDriverHandles) {
+    // Fork safety: the loader's zeInit() is a process-lifetime std::call_once, so in a
+    // forked child it returns the parent's cached result without ever calling into this
+    // driver again. zeDriverGet is the first driver entry point the child actually
+    // reaches, so detect the pid change here and re-initialize.
+    auto currentPid = NEO::SysCalls::getCurrentProcessId();
+    if (this->pid != currentPid && initStatus == ZE_RESULT_SUCCESS) {
+        std::lock_guard<std::mutex> lock(driverInitMutex);
+        if (this->pid != currentPid) {
+            ze_result_t reinitResult;
+            this->initialize(&reinitResult);
+            levelZeroDriverInitialized = (reinitResult == ZE_RESULT_SUCCESS);
+        }
+    }
+
     // Only attempt to Init GtPin when driverHandleGet is called requesting handles.
     if (phDriverHandles != nullptr && *pCount > 0) {
         Driver::get()->tryInitGtpin();
     }
-    auto driverCount = static_cast<uint32_t>(globalDriverHandles->size());
+
+    // Filter out orphaned handles from fork
+    std::vector<ze_driver_handle_t> validHandles;
+    for (auto *handle : *globalDriverHandles) {
+        auto *driverHandle = DriverHandle::fromHandle(handle);
+        if (driverHandle && !driverHandle->isOrphanedFromFork) {
+            validHandles.push_back(handle);
+        }
+    }
+
+    auto driverCount = static_cast<uint32_t>(validHandles.size());
     if (*pCount == 0) {
         *pCount = driverCount;
         return ZE_RESULT_SUCCESS;
@@ -139,7 +202,7 @@ ze_result_t Driver::driverHandleGet(uint32_t *pCount, ze_driver_handle_t *phDriv
     }
 
     for (uint32_t i = 0; i < *pCount; i++) {
-        phDriverHandles[i] = (*globalDriverHandles)[i];
+        phDriverHandles[i] = validHandles[i];
     }
 
     return ZE_RESULT_SUCCESS;
@@ -159,12 +222,19 @@ void Driver::tryInitGtpin() {
 
 static Driver driverInstance;
 Driver *Driver::driver = &driverInstance;
-std::mutex driverInitMutex;
 
 ze_result_t initDriver() {
     auto pid = NEO::SysCalls::getCurrentProcessId();
 
     ze_result_t result = Driver::get()->driverInit();
+
+    // Register fork handler on first successful init
+    static std::once_flag forkHandlerOnce;
+    if (result == ZE_RESULT_SUCCESS) {
+        std::call_once(forkHandlerOnce, []() {
+            pthread_atfork(nullptr, nullptr, driverForkChildHandler);
+        });
+    }
 
     if (Driver::get()->getPid() != pid) {
         std::lock_guard<std::mutex> lock(driverInitMutex);

--- a/level_zero/core/source/driver/driver.h
+++ b/level_zero/core/source/driver/driver.h
@@ -27,6 +27,10 @@ class Driver {
         return pid;
     }
 
+    void setPid(uint32_t newPid) {
+        pid = newPid;
+    }
+
   protected:
     static Driver *driver;
     uint32_t pid = 0;

--- a/level_zero/core/source/driver/driver_handle.h
+++ b/level_zero/core/source/driver/driver_handle.h
@@ -227,6 +227,9 @@ class DriverHandle : public BaseDriver, public NEO::NonCopyableAndNonMovableClas
     std::once_flag hostUsmPoolOnceFlag;
     std::once_flag deviceUsmPoolOnceFlag;
 
+    // Fork safety: track if this handle was inherited from parent via fork()
+    bool isOrphanedFromFork = false;
+
     // Error messages per thread, variable initialized / destroyed per thread,
     // not based on the lifetime of the object of a class.
     std::unordered_map<std::thread::id, std::string> errorDescs;


### PR DESCRIPTION
## Problem

`fork()` is broken for Level Zero on Linux when the parent has already initialized the driver. Depending on timing, a forked child either deadlocks on its first GPU call or gets `0` drivers back from `zeDriverGet`.

## Root cause

The Level Zero **loader** (`libze_loader`, verified on 1.28.6) runs `zeInit()` inside a process-lifetime `std::call_once`. A forked child inherits the consumed `once_flag` and the cached `ZE_RESULT_SUCCESS`, so the child's `zeInit()` short-circuits in the loader and **never calls back into this driver**. The driver's existing pid-check re-init path in `initDriver()` is therefore unreachable after `fork()` — it only runs under the loader's init callback, which fires once per process lifetime of the *parent*.

The loader's `zeDriverGet`, by contrast, is a direct jump into the driver's entry point with no init logic (verified by disassembly). So `zeDriverGet` → `Driver::driverHandleGet()` is the first place the driver code actually executes in a forked child.

Evidence gathered while root-causing (strace of failing children shows zero GPU-related syscalls — no `/dev/dri` opens — proving `Driver::initialize()` never ran in the child; calling the driver's DDI tables directly, bypassing the loader, made fork work even without this patch).

## Fix

1. **`pthread_atfork` child handler** (registered on first successful init): resets the driver pid and marks inherited driver handles as orphaned — they wrap DRM fds that belong to the parent.
2. **Pid-change detection in `Driver::driverHandleGet()`**: re-initializes the driver when called from a new pid, since this is the earliest point the driver can observe the fork given the loader behavior above.
3. **Orphaned handles are dropped from `globalDriverHandles` but intentionally leaked, never deleted**: the child shares the parent's DRM file *descriptions*, so destructor teardown (GEM close / context destroy ioctls) would destroy the parent's live GPU objects. This mirrors the pid-match policy `globalDriverTeardown()` already implements, and matches the leak-on-fork convention other GPU runtimes use.

## Verification

Tested on Meteor Lake (Core Ultra 5 125H, Arc iGPU, Ubuntu 24.04, kernel 6.17, loader 1.28.6), built from the 26.28 source base with the same change and installed as `libze_intel_gpu.so.1.15.0`:

- loader-path fork test (parent inits via loader, forks 3 children, each child calls `zeInit` + `zeDriverGet` + creates a context and runs work): 3/3 children pass; before the change all children either deadlocked or saw 0 drivers
- direct-DDI fork test (bypassing the loader): 3/3 pass
- grandchild fork test (fork from a forked child): 3/3 pass
- parent unaffected after children exit (its contexts/allocations stay live — this is what the leak-don't-delete policy protects)

## Honest caveats

- Developed and hardware-verified against the 26.28 release base; rebased onto current master (applies cleanly, and the symbols it relies on — `initStatus`, `DriverHandle::pid`, `std::erase_if` — are all present), but I have not run a full master build or the ULT suite on master.
- No new ULTs are included yet. If maintainers are interested in this direction I'm happy to add fork-simulation unit tests (e.g. pid-spoofing around `driverHandleGet`) — guidance on the preferred pattern welcome.
- An alternative/complementary fix would be a `pthread_atfork`-based reset of the `call_once` state in the **loader** (oneapi-src/level-zero); this PR fixes what the driver can do unilaterally, which is sufficient to make fork work end-to-end.