### PR TITLE
performance(ocl): skip WaitUtils yield on clSetEventCallback probe

### DIFF
--- a/opencl/source/api/api.cpp
+++ b/opencl/source/api/api.cpp
@@ -21,6 +21,7 @@
 #include "shared/source/os_interface/device_factory.h"
 #include "shared/source/os_interface/leo_supported_exception.h"
 #include "shared/source/utilities/buffer_pool_allocator.inl"
+#include "shared/source/utilities/wait_util.h"
 
 #include "opencl/source/api/additional_extensions.h"
 #include "opencl/source/api/api_enter.h"
@@ -2324,6 +2325,9 @@ cl_int CL_API_CALL clSetEventCallback(cl_event event,
         TRACING_EXIT(ClSetEventCallback, &retVal);
         return retVal;
     }
+
+    /* Cover tryFlushEvent + addCallback (both may probe completion via WaitUtils). */
+    WaitUtils::SkipYieldGuard skipYieldOnSetCb;
 
     if (eventObject->tryFlushEvent() == false) {
         retVal = CL_OUT_OF_RESOURCES;

--- a/shared/source/utilities/wait_util.h
+++ b/shared/source/utilities/wait_util.h
@@ -48,6 +48,23 @@ extern uint32_t waitpkgControlValue;
 extern uint32_t waitCount;
 extern bool waitpkgSupport;
 
+/* clSetEventCallback may probe completion non-blockingly; yielding on a
+ * not-ready tag poll can stall the caller for multiple ms under load.
+ * Activate SkipYieldGuard around that path so miss returns immediately.
+ */
+inline thread_local uint32_t skipYieldNestingDepth = 0;
+
+struct SkipYieldGuard {
+    SkipYieldGuard() { ++skipYieldNestingDepth; }
+    ~SkipYieldGuard() { --skipYieldNestingDepth; }
+    SkipYieldGuard(const SkipYieldGuard &) = delete;
+    SkipYieldGuard &operator=(const SkipYieldGuard &) = delete;
+};
+
+inline bool shouldSkipYield() {
+    return skipYieldNestingDepth > 0;
+}
+
 inline void tpause(uint64_t counterValue) {
     uint64_t currentCounter = CpuIntrinsics::rdtsc() + counterValue;
     CpuIntrinsics::tpause(waitpkgControlValue, currentCounter);
@@ -85,7 +102,9 @@ inline bool waitFunctionWithPredicate(volatile T const *pollAddress, T expectedV
             }
         }
     }
-    std::this_thread::yield();
+    if (!shouldSkipYield()) {
+        std::this_thread::yield();
+    }
     return false;
 }
 


### PR DESCRIPTION
## Prelude:
I am open to feedback and very willing to rework this patch as needed to get it merged. Please tell me what you'd like changed and I'll update the patch.

## What is happening?
Not-ready tag polls in setCb were calling std::this_thread::yield(). These yield() calls are unnecessary when the user is using the asynchronous flow (i.e: using clSetEventCallback()). In the asynchronous flow, NEO should check for GPU kernel completion __once__, and then if the kernel hasn't already finished executing, then NEO should proceed to enqueue the callback on the async queue -- and it should do this __without__ calling yield().

## Why is this a problem?
The problem is that this superfluous yield() causes periodic spikes of 5ms or more, which the user is forced to wait for. This significantly degrades the latency of realtime applications which are trying to use the GPU. An extra 5-10ms is a big deal if you have a 33ms budget to work with.

## Proposed solution:
I've implemented the minimum necessary change here: just use a thread-local var to tell NEO when it should __not__ call yield().
